### PR TITLE
Enabling new metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.8-alpine
 
+COPY conf/ /exporter/conf/
 COPY druid_exporter/ /exporter/druid_exporter/
 COPY setup.py /exporter/setup.py
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.8-alpine
+
+COPY druid_exporter/ /exporter/druid_exporter/
+COPY setup.py /exporter/setup.py
+
+WORKDIR /exporter
+
+RUN python ./setup.py install
+
+EXPOSE 8000
+
+ENTRYPOINT ["python", "-u", "druid_exporter/exporter.py"]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,26 @@ The easiest way to run `druid_exporter` is via a virtualenv:
 
 By default metrics are exposed on TCP port `8000`. Python 2 is not supported.
 
+### Running with Docker
+
+Issue the following command to build the image and run:
+
+```bash
+docker build -t druid-exporter:latest .
+docker run -it -d -p 8000:8000 druid-exporter:latest conf/example_druid_0_12_3.json
+```
+
+Example `docker-compose.yml`:
+```yaml
+druid-exporter:
+  image: "druid-exporter:latest"
+  command: 
+    - "conf/example_druid_0_12_3.json"
+  ports:
+    - published: 8000
+      target: 8000
+```
+
 ## Druid versions supported
 
 This exporter is tested and used by the Wikimedia foundation with Druid version 0.12.3,

--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ This exporter is supposed to be run on each host running a Druid daemon.
 * `query/cache/total/timeouts`
 * `query/cache/total/errors`
 
+### Coordinator (histograms)
+* `task/run/time` [dataSource]
+* `task/action/log/time` [dataSource]
+* `task/action/run/time` [dataSource]
+
+### MiddleManager (histograms)
+* `query/time` [dataSource]
+* `query/bytes` [dataSource]
+* `ingest/persists/time` [dataSource]
+* `ingest/persists/cpu` [dataSource]
+* `ingest/persists/backPressure` [dataSource]
+* `ingest/merge/time` [dataSource]
+* `ingest/merge/cpu` [dataSource]
+
 ### Historical, Coordinator (counters)
 * `segment/max` [datasource]
 * `segment/count` [datasource]
@@ -65,24 +79,40 @@ This exporter is supposed to be run on each host running a Druid daemon.
 * `segment/deleted/count` [tier]
 * `segment/unneeded/count` [tier]
 * `segment/overShadowed/count`
+* `segment/loadQueue/size` [server]
 * `segment/loadQueue/failed` [server]
 * `segment/loadQueue/count` [server]
 * `segment/dropQueue/count` [server]
 * `segment/size` [datasource]
 * `segment/unavailable/count` [datasource]
 * `segment/underReplicated/count` [datasource, tier]
+* `tier/historical/count` [tier]
+* `tier/replication/factor` [tier]
+* `tier/required/capacity` [tier]
+* `tier/total/capacity` [tier]
+* `ingest/kafka/lag` [datasource]
+* `ingest/kafka/maxLag` [datasource]
+* `ingest/kafka/avgLag` [datasource]
+* `task/success/count` [datasource]
+* `task/failed/count` [datasource]
+* `task/running/count` [datasource]
+* `task/pending/count` [datasource]
+* `task/waiting/count` [datasource]
 
-### Peon (counters)
+### MiddleManager (counters)
 * `query/time` [datasource]
 * `query/bytes` [datasource]
-* `ingest/events/thrownAway` [dataSource]
-* `ingest/events/unparseable` [dataSource]
-* `ingest/events/processed` [dataSource]
-* `ingest/rows/output` [dataSource]
-* `ingest/persists/count` [dataSource]
-* `ingest/persists/failed` [dataSource]
-* `ingest/handoff/failed` [dataSource]
-* `ingest/handoff/count` [dataSource]
+* `ingest/events/thrownAway` [datasource, taskid]
+* `ingest/events/unparseable` [datasource, taskid]
+* `ingest/events/duplicate` [datasource, taskid]
+* `ingest/events/processed` [datasource, taskid]
+* `ingest/rows/output` [datasource, taskid]
+* `ingest/persists/count` [datasource, taskid]
+* `ingest/persists/failed` [datadatasource, taskidSource]
+* `ingest/handoff/failed` [datdatasource, taskidaSource]
+* `ingest/handoff/count` [datasource, taskid]
+* `ingest/sink/count` [datadatasource, taskidSource]
+* `ingest/events/messageGap` [datdatasource, taskidaSource]
 
 Realtime metrics have been tested only when emitted by Peons, since the Wikimedia
 use case (for the moment) is to use [Tranquillity](https://github.com/druid-io/tranquility)

--- a/conf/example_druid_v_0_17_0.json
+++ b/conf/example_druid_v_0_17_0.json
@@ -1,0 +1,775 @@
+{
+    "broker": {
+        "query/time": {
+            "prometheus_metric_name": "druid_broker_query_time_ms",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Milliseconds taken to complete a query."
+        },
+        "query/bytes": {
+            "druid_metric_name": "query/bytes",
+            "prometheus_metric_name": "druid_broker_query_bytes",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Number of bytes returned in query response."
+        },
+        "query/cache/total/numEntries": {
+            "prometheus_metric_name": "druid_broker_query_cache_numentries_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache entries."
+        },
+        "query/cache/total/sizeBytes": {
+            "prometheus_metric_name": "druid_broker_query_cache_size_bytes",
+            "daemon": "broker",
+            "type": "gauge",
+            "labels": [],
+            "description": "Size in bytes of cache entries."
+        },
+        "query/cache/total/hits": {
+            "prometheus_metric_name": "druid_broker_query_cache_hits_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache hits."
+        },
+        "query/cache/total/misses": {
+            "prometheus_metric_name": "druid_broker_query_cache_misses_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache misses."
+        },
+        "query/cache/total/evictions": {
+            "prometheus_metric_name": "druid_broker_query_cache_evictions_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache evictions."
+        },
+        "query/cache/total/timeouts": {
+            "prometheus_metric_name": "druid_broker_query_cache_timeouts_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache timeouts."
+        },
+        "query/cache/total/errors": {
+            "prometheus_metric_name": "druid_broker_query_cache_errors_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache errors."
+        },
+        "query/count": {
+            "prometheus_metric_name": "druid_broker_query_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of queries."
+        },
+        "query/success/count": {
+            "prometheus_metric_name": "druid_broker_success_query_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of Successfull queries."
+        },
+        "query/failed/count": {
+            "prometheus_metric_name": "druid_broker_failed_query_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of failed queries."
+        },
+        "query/interrupted/count": {
+            "prometheus_metric_name": "druid_broker_interrupted_query_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of interrupted queries."
+        }
+    },
+    "historical": {
+        "query/time": {
+            "prometheus_metric_name": "druid_historical_query_time_ms",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Milliseconds taken to complete a query."
+        },
+        "query/bytes": {
+            "prometheus_metric_name": "druid_historical_query_bytes",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Number of bytes returned in query response."
+        },
+        "segment/max": {
+            "prometheus_metric_name": "druid_historical_max_segment_bytes",
+            "type": "gauge",
+            "labels": [],
+            "description": "Maximum byte limit available for segments."
+        },
+        "segment/count": {
+            "prometheus_metric_name": "druid_historical_segment_count",
+            "type": "gauge",
+            "labels": [
+                "tier",
+                "dataSource"
+            ],
+            "description": "Number of served segments."
+        },
+        "segment/used": {
+            "prometheus_metric_name": "druid_historical_segment_used_bytes",
+            "type": "gauge",
+            "labels": [
+                "tier",
+                "dataSource"
+            ],
+            "description": "Bytes used for served segments."
+        },
+        "segment/scan/pending": {
+            "prometheus_metric_name": "druid_historical_segment_scan_pending",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of segments in queue waiting to be scanned."
+        },
+        "query/cache/total/numEntries": {
+            "prometheus_metric_name": "druid_historical_query_cache_numentries_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache entries."
+        },
+        "query/cache/total/sizeBytes": {
+            "prometheus_metric_name": "druid_historical_query_cache_size_bytes",
+            "type": "gauge",
+            "labels": [],
+            "description": "Size in bytes of cache entries."
+        },
+        "query/cache/total/hits": {
+            "prometheus_metric_name": "druid_historical_query_cache_hits_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache hits."
+        },
+        "query/cache/total/misses": {
+            "prometheus_metric_name": "druid_historical_query_cache_misses_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache misses."
+        },
+        "query/cache/total/evictions": {
+            "prometheus_metric_name": "druid_historical_query_cache_evictions_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache evictions."
+        },
+        "query/cache/total/timeouts": {
+            "prometheus_metric_name": "druid_historical_query_cache_timeouts_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache timeouts."
+        },
+        "query/cache/total/errors": {
+            "prometheus_metric_name": "druid_historical_query_cache_errors_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache errors."
+        },
+        "query/count": {
+            "prometheus_metric_name": "druid_historical_query_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of queries."
+        },
+        "query/success/count": {
+            "prometheus_metric_name": "druid_historical_success_query_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of Successfull queries."
+        },
+        "query/failed/count": {
+            "prometheus_metric_name": "druid_historical_failed_query_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of failed queries."
+        },
+        "query/interrupted/count": {
+            "prometheus_metric_name": "druid_historical_interrupted_query_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of interrupted queries."
+        }
+    },
+    "middlemanager": {
+        "query/time": {
+            "prometheus_metric_name": "druid_middlemanager_query_time_ms",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Milliseconds taken to complete a query."
+        },
+        "query/bytes": {
+            "druid_metric_name": "query/bytes",
+            "prometheus_metric_name": "druid_middlemanager_query_bytes",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Number of bytes returned in query response."
+        },
+        "ingest/events/thrownAway": {
+            "prometheus_metric_name": "druid_realtime_ingest_events_thrown_away_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Number of events rejected because they are outside the windowPeriod."
+        },
+        "ingest/events/unparseable": {
+            "prometheus_metric_name": "druid_realtime_ingest_events_unparseable_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Number of events rejected because the events are unparseable."
+        },
+        "ingest/events/duplicate": {
+            "prometheus_metric_name": "druid_realtime_ingest_events_duplicate_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Number of events rejected because the events are duplicated."
+        },
+        "ingest/events/processed": {
+            "prometheus_metric_name": "druid_realtime_ingest_events_processed_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Number of events successfully processed per emission period."
+        },
+        "ingest/rows/output": {
+            "prometheus_metric_name": "druid_realtime_ingest_rows_output_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Number of Druid rows persisted."
+        },
+        "ingest/persists/count": {
+            "prometheus_metric_name": "druid_realtime_ingest_persists_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Number of events successfully persisted."
+        },
+        "ingest/persists/time": {
+            "prometheus_metric_name": "druid_realtime_ingest_persists_time",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Milliseconds spent doing intermediate persist."
+        },
+        "ingest/persists/cpu": {
+            "prometheus_metric_name": "druid_realtime_ingest_persists_cpu",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Cpu time in Nanoseconds spent on doing intermediate persist."
+        },
+        "ingest/persists/backPressure": {
+            "prometheus_metric_name": "druid_realtime_ingest_persists_backpressure",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Milliseconds spent creating persist tasks and blocking waiting for them to finish."
+        },
+        "ingest/persists/failed": {
+            "prometheus_metric_name": "druid_realtime_ingest_persists_failed_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Number of times persist failed."
+        },
+        "ingest/handoff/failed": {
+            "prometheus_metric_name": "druid_realtime_ingest_handoff_failed_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Number of times handoff failed."
+        },
+        "ingest/handoff/count": {
+            "prometheus_metric_name": "druid_realtime_ingest_handoff_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Number of times handoff has happened."
+        },
+        "ingest/merge/time": {
+            "prometheus_metric_name": "druid_realtime_ingest_merge_time",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Milliseconds spent merging intermediate segments."
+        },
+        "ingest/merge/cpu": {
+            "prometheus_metric_name": "druid_realtime_ingest_merge_cpu",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Cpu time in Nanoseconds spent on merging intermediate segments."
+        },
+        "ingest/sink/count": {
+            "prometheus_metric_name": "druid_realtime_ingest_sink_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Number of sinks not handoffed."
+        },
+        "ingest/events/messageGap": {
+            "prometheus_metric_name": "druid_realtime_ingest_events_messagegap",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Time gap between the data time in event and current system time."
+        }
+    },
+    "coordinator": {
+        "segment/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Number of served segments."
+        },
+        "segment/assigned/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_assigned_count",
+            "type": "gauge",
+            "labels": [
+                "tier"
+            ],
+            "description": "Number of segments assigned to be loaded in the cluster."
+        },
+        "segment/moved/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_moved_count",
+            "type": "gauge",
+            "labels": [
+                "tier"
+            ],
+            "description": "Number of segments assigned to be loaded in the cluster."
+        },
+        "segment/dropped/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_dropped_count",
+            "type": "gauge",
+            "labels": [
+                "tier"
+            ],
+            "description": "Number of segments dropped due to being overshadowed."
+        },
+        "segment/deleted/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_deleted_count",
+            "type": "gauge",
+            "labels": [
+                "tier"
+            ],
+            "description": "Number of segments dropped due to rules."
+        },
+        "segment/unneeded/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_unneeded_count",
+            "type": "gauge",
+            "labels": [
+                "tier"
+            ],
+            "description": "Number of segments dropped due to being marked as unused."
+        },
+        "segment/overShadowed/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_overshadowed_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of overShadowed segments."
+        },
+        "segment/loadQueue/size": {
+            "prometheus_metric_name": "druid_coordinator_segment_loadqueue_size_bytes",
+            "type": "gauge",
+            "labels": [
+                "server"
+            ],
+            "description": "Size in bytes of segments to load."
+        },
+        "segment/loadQueue/failed": {
+            "prometheus_metric_name": "druid_coordinator_segment_loadqueue_failed_count",
+            "type": "gauge",
+            "labels": [
+                "server"
+            ],
+            "description": "Number of segments that failed to load."
+        },
+        "segment/loadQueue/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_loadqueue_count",
+            "type": "gauge",
+            "labels": [
+                "server"
+            ],
+            "description": "Number of segments to load."
+        },
+        "segment/dropQueue/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_dropqueue_count",
+            "type": "gauge",
+            "labels": [
+                "server"
+            ],
+            "description": "Number of segments to drop."
+        },
+        "segment/size": {
+            "prometheus_metric_name": "druid_coordinator_segment_size_bytes",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Size in bytes of available segments."
+        },
+        "segment/unavailable/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_unavailable_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Number of segments (not including replicas) left to load until segments that should be loaded in the cluster are available for queries."
+        },
+        "segment/underReplicated/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_under_replicated_count",
+            "type": "gauge",
+            "labels": [
+                "tier",
+                "dataSource"
+            ],
+            "description": "Number of segments (including replicas) left to load until segments that should be loaded in the cluster are available for queries."
+        },
+        "tier/historical/count": {
+            "prometheus_metric_name": "druid_coordinator_tier_historical_count",
+            "type": "gauge",
+            "labels": [
+                "tier"
+            ],
+            "description": "Number of available historical nodes in each tier."
+        },
+        "tier/replication/factor": {
+            "prometheus_metric_name": "druid_coordinator_tier_replication_count",
+            "type": "gauge",
+            "labels": [
+                "tier"
+            ],
+            "description": "Configured maximum replication factor in each tier."
+        },
+        "tier/required/capacity": {
+            "prometheus_metric_name": "druid_coordinator_tier_required_capacity_bytes",
+            "type": "gauge",
+            "labels": [
+                "tier"
+            ],
+            "description": "Total capacity in bytes required in each tier."
+        },
+        "tier/total/capacity": {
+            "prometheus_metric_name": "druid_coordinator_tier_total_capacity_bytes",
+            "type": "gauge",
+            "labels": [
+                "tier"
+            ],
+            "description": "Total capacity in bytes available in each tier."
+        },
+        "ingest/kafka/lag": {
+            "prometheus_metric_name": "druid_realtime_ingest_kafka_lag",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Total lag between the offsets consumed by the Kafka indexing tasks and latest offsets in Kafka brokers across all partitions."
+        },
+        "ingest/kafka/maxLag": {
+            "prometheus_metric_name": "druid_realtime_ingest_kafka_maxlag",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Max lag between the offsets consumed by the Kafka indexing tasks and latest offsets in Kafka brokers across all partitions."
+        },
+        "ingest/kafka/avgLag": {
+            "prometheus_metric_name": "druid_realtime_ingest_kafka_avglag",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Average lag between the offsets consumed by the Kafka indexing tasks and latest offsets in Kafka brokers across all partitions."
+        },
+        "task/success/count": {
+            "prometheus_metric_name": "druid_coordinator_task_success_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Number of successful tasks per emission period."
+        },
+        "task/failed/count": {
+            "prometheus_metric_name": "druid_coordinator_task_failed_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Number of failed tasks per emission period."
+        },
+        "task/running/count": {
+            "prometheus_metric_name": "druid_coordinator_task_running_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Number of current running tasks."
+        },
+        "task/pending/count": {
+            "prometheus_metric_name": "druid_coordinator_task_pending_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Number of current pending tasks."
+        },
+        "task/waiting/count": {
+            "prometheus_metric_name": "druid_coordinator_task_waiting_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Number of current waiting tasks."
+        },
+        "task/run/time": {
+            "prometheus_metric_name": "druid_coordinator_task_run_time",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Milliseconds taken to run a task."
+        },
+        "task/action/log/time": {
+            "prometheus_metric_name": "druid_coordinator_task_action_log_time",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Milliseconds taken to log a task action to the audit log."
+        },
+        "task/action/run/time": {
+            "prometheus_metric_name": "druid_coordinator_task_action_run_time",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Milliseconds taken to execute a task action."
+        }
+    }
+}


### PR DESCRIPTION
This PR:
* Enabled realtime metrics emitted from MiddleManager.
* Added taskID label to realtime metrics.
* Added new counter metrics emitted from Coordinator.
* Added new histogram metrics emitted from Coordinator and MiddleManager.
* Added a sample Dockerfile
* Is tested with Druid Cluster with Kafka Indexing Service enabled.
