### PR TITLE
Add config for V18 + allow router + util to generate config for new metrics

### DIFF
--- a/conf/druid_0_18_0.json
+++ b/conf/druid_0_18_0.json
@@ -554,6 +554,223 @@
         }
     },
     "historical": {
+        "jvm/heapAlloc/bytes": {
+            "buckets": [
+                "10", 
+                "100", 
+                "500", 
+                "1000", 
+                "2000", 
+                "3000", 
+                "5000", 
+                "7000", 
+                "10000", 
+                "inf", 
+                "sum"
+            ], 
+            "description": "druid_jvm_heapAlloc_bytes", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_jvm_heapAlloc_bytes", 
+            "type": "histogram"
+        },
+        "jvm/gc/mem/init": {
+            "description": "druid_jvm_gc_mem_init",
+            "labels": [],
+            "prometheus_metric_name": "druid_jvm_gc_mem_init",
+            "type": "gauge"
+        },
+        "jvm/gc/mem/used": {
+            "description": "druid_jvm_gc_mem_used",
+            "labels": [],
+            "prometheus_metric_name": "druid_jvm_gc_mem_used",
+            "type": "gauge"
+        },
+        "jvm/gc/mem/capacity": {
+            "description": "druid_jvm_gc_mem_capacity",
+            "labels": [],
+            "prometheus_metric_name": "druid_jvm_gc_mem_capacity",
+            "type": "gauge"
+        },
+        "jvm/gc/mem/max": {
+            "description": "druid_jvm_gc_mem_max",
+            "labels": [],
+            "prometheus_metric_name": "druid_jvm_gc_mem_max",
+            "type": "gauge"
+        },
+        "jvm/gc/cpu": {
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "description": "Count of CPU time in Nanoseconds spent on garbage collection. Note: jvm/gc/cpu represents the total time over multiple GC cycles; divide by jvm/gc/count to get the mean GC time per cycle",
+            "labels": [],
+            "prometheus_metric_name": "druid_jvm_gc_cpu",
+            "type": "histogram"
+        },
+        "jvm/gc/count": {
+            "description": "Garbage collection count.",
+            "labels": [],
+            "prometheus_metric_name": "druid_jvm_gc_count",
+            "type": "gauge"
+        },
+        "jvm/bufferpool/count": {
+            "description": "Bufferpool count.",
+            "labels": [
+                "bufferpoolName"
+            ],
+            "prometheus_metric_name": "druid_jvm_bufferpool_count",
+            "type": "gauge"
+        },
+        "jvm/bufferpool/used": {
+            "description": "Bufferpool used.",
+            "labels": [
+                "bufferpoolName"
+            ],
+            "prometheus_metric_name": "druid_jvm_bufferpool_used",
+            "type": "gauge"
+        },
+        "jvm/bufferpool/capacity": {
+            "description": "Bufferpool capacity.",
+            "labels": [
+                "bufferpoolName"
+            ],
+            "prometheus_metric_name": "druid_jvm_bufferpool_capacity",
+            "type": "gauge"
+        },
+        "jvm/pool/init": {
+            "description": "Initial pool.",
+            "labels": [],
+            "prometheus_metric_name": "druid_jvm_pool_init",
+            "type": "gauge"
+        },
+        "jvm/pool/used": {
+            "description": "Pool used.",
+            "labels": [],
+            "prometheus_metric_name": "druid_jvm_pool_used",
+            "type": "gauge"
+        },
+        "jvm/pool/committed": {
+            "description": "Committed pool.",
+            "labels": [],
+            "prometheus_metric_name": "druid_jvm_pool_committed",
+            "type": "gauge"
+        },
+        "jvm/pool/max": {
+            "description": "Max pool.",
+            "labels": [],
+            "prometheus_metric_name": "druid_jvm_pool_max",
+            "type": "gauge"
+        },
+        "jvm/mem/init": {
+            "description": "Initial memory.",
+            "labels": [
+                "memKind"
+            ],
+            "prometheus_metric_name": "druid_jvm_mem_init",
+            "type": "gauge"
+        },
+        "jvm/mem/used": {
+            "description": "Used memory.",
+            "labels": [
+                "memKind"
+            ],
+            "prometheus_metric_name": "druid_jvm_mem_used",
+            "type": "gauge"
+        },
+        "jvm/mem/committed": {
+            "description": "Committed memory.",
+            "labels": [
+                "memKind"
+            ],
+            "prometheus_metric_name": "druid_jvm_mem_committed",
+            "type": "gauge"
+        },
+        "jvm/mem/max": {
+            "description": "Max memory.",
+            "labels": [
+                "memKind"
+            ],
+            "prometheus_metric_name": "druid_jvm_mem_max",
+            "type": "gauge"
+        },
+        "jetty/numOpenConnections": {
+            "description": "Number of open jetty connections.",
+            "labels": [],
+            "prometheus_metric_name": "druid_jetty_numOpenConnections",
+            "type": "gauge"
+        },
+        "query/cpu/time": {
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "description": "Microseconds of CPU time taken to complete a query",
+            "labels": [
+                "dataSource"
+            ],
+            "prometheus_metric_name": "druid_query_cpu_time",
+            "type": "histogram"
+        },
+        "query/segmentAndCache/time": {
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "description": "Milliseconds taken to query individual segment or hit the cache (if it is enabled on the Historical process).",
+            "labels": [
+                "dataSource"
+            ],
+            "prometheus_metric_name": "druid_query_segmentAndCache_time",
+            "type": "histogram"
+        },
+        "query/wait/time": {
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "description": "Milliseconds spent waiting for a segment to be scanned.",
+            "labels": [
+                "dataSource"
+            ],
+            "prometheus_metric_name": "druid_query_wait_time",
+            "type": "histogram"
+        },
         "query/time": {
             "prometheus_metric_name": "druid_historical_query_time_ms",
             "type": "histogram",

--- a/conf/druid_0_18_0.json
+++ b/conf/druid_0_18_0.json
@@ -729,6 +729,25 @@
             "prometheus_metric_name": "druid_query_cpu_time",
             "type": "histogram"
         },
+        "query/segment/time": {
+            "buckets": [
+                "10", 
+                "100", 
+                "500", 
+                "1000", 
+                "2000", 
+                "3000", 
+                "5000", 
+                "7000", 
+                "10000", 
+                "inf", 
+                "sum"
+            ], 
+            "description": "Milliseconds taken to query individual segment. Includes time to page in the segment from disk.", 
+            "labels": ["dataSource"], 
+            "prometheus_metric_name": "druid_query_segment_time", 
+            "type": "histogram"
+        },
         "query/segmentAndCache/time": {
             "buckets": [
                 "10",
@@ -908,6 +927,24 @@
             "type": "gauge",
             "labels": [],
             "description": "Number of interrupted queries."
+        },
+        "namespace/cache/heapSizeInBytes": {
+            "description": "druid_namespace_cache_heapSizeInBytes", 
+            "labels": [], 
+            "prometheus_metric_name": "druid_namespace_cache_heapSizeInBytes", 
+            "type": "gauge"
+        },
+        "namespace/cache/numEntries": {
+            "description": "druid_namespace_cache_numEntries", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_namespace_cache_numEntries", 
+            "type": "gauge"
+        },
+        "namespace/deltaTasksStarted": {
+            "description": "druid_namespace_deltaTasksStarted", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_namespace_deltaTasksStarted", 
+            "type": "gauge"
         }
     },
     "middlemanager": {

--- a/conf/druid_0_18_0.json
+++ b/conf/druid_0_18_0.json
@@ -179,6 +179,44 @@
             ],
             "description": "Number of bytes returned in query response."
         },
+        "sqlQuery/time": {
+            "buckets": [
+                "10", 
+                "100", 
+                "500", 
+                "1000", 
+                "2000", 
+                "3000", 
+                "5000", 
+                "7000", 
+                "10000", 
+                "inf", 
+                "sum"
+            ], 
+            "description": "Milliseconds taken to complete a SQL.", 
+            "labels": "dataSource", 
+            "prometheus_metric_name": "druid_sqlQuery_time", 
+            "type": "histogram"
+        },
+        "sqlQuery/bytes": {
+            "buckets": [
+                "10", 
+                "100", 
+                "500", 
+                "1000", 
+                "2000", 
+                "3000", 
+                "5000", 
+                "7000", 
+                "10000", 
+                "inf", 
+                "sum"
+            ], 
+            "description": "number of bytes returned in SQL response.", 
+            "labels": "dataSource", 
+            "prometheus_metric_name": "druid_sqlQuery_bytes", 
+            "type": "histogram"
+        },    
         "query/cache/total/numEntries": {
             "prometheus_metric_name": "druid_broker_query_cache_numentries_count",
             "type": "gauge",

--- a/conf/druid_0_18_0.json
+++ b/conf/druid_0_18_0.json
@@ -1,5 +1,24 @@
 {
     "router": {
+        "jvm/heapAlloc/bytes": {
+            "buckets": [
+                "10", 
+                "100", 
+                "500", 
+                "1000", 
+                "2000", 
+                "3000", 
+                "5000", 
+                "7000", 
+                "10000", 
+                "inf", 
+                "sum"
+            ], 
+            "description": "druid_jvm_heapAlloc_bytes", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_jvm_heapAlloc_bytes", 
+            "type": "histogram"
+        },    
         "jetty/numOpenConnections": {
             "description": "Number of open jetty connections.", 
             "labels": "[]", 
@@ -142,6 +161,24 @@
         }
     },
     "broker": {
+        "namespace/cache/heapSizeInBytes": {
+            "description": "druid_namespace_cache_heapSizeInBytes", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_namespace_cache_heapSizeInBytes", 
+            "type": "gauge"
+        },
+        "jvm/gc/mem/init": {
+            "description": "druid_jvm_gc_mem_init", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_jvm_gc_mem_init", 
+            "type": "gauge"
+        },
+        "jvm/gc/mem/capacity": {
+            "description": "druid_jvm_gc_mem_capacity", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_jvm_gc_mem_capacity", 
+            "type": "gauge"
+        },
         "jvm/gc/mem/max": {
             "description": "druid_jvm_gc_mem_max", 
             "labels": "[]", 

--- a/conf/druid_0_18_0.json
+++ b/conf/druid_0_18_0.json
@@ -1,0 +1,1189 @@
+{
+    "router": {
+        "jvm/heapAlloc/bytes": {
+            "buckets": [
+                "10", 
+                "100", 
+                "500", 
+                "1000", 
+                "2000", 
+                "3000", 
+                "5000", 
+                "7000", 
+                "10000", 
+                "inf", 
+                "sum"
+            ], 
+            "description": "druid_jvm_heapAlloc_bytes", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_jvm_heapAlloc_bytes", 
+            "type": "histogram"
+        },    
+        "jetty/numOpenConnections": {
+            "description": "Number of open jetty connections.", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_jetty_numOpenConnections", 
+            "type": "gauge"
+        },
+        "query/time": {
+            "buckets": [
+                "10", 
+                "100", 
+                "500", 
+                "1000", 
+                "2000", 
+                "3000", 
+                "5000", 
+                "7000", 
+                "10000", 
+                "inf", 
+                "sum"
+            ], 
+            "description": "Milliseconds taken to complete a query", 
+            "labels": "dataSource", 
+            "prometheus_metric_name": "druid_query_time", 
+            "type": "histogram"
+        },
+        "jvm/mem/committed": {
+            "description": "Committed memory", 
+            "prometheus_metric_name": "druid_jvm_mem_committed", 
+            "labels": "[]", 
+            "type": "gauge"
+        },
+        "jvm/mem/used": {
+            "description": "Used memory", 
+            "prometheus_metric_name": "druid_jvm_mem_used", 
+            "labels": "[]", 
+            "type": "gauge"
+        },
+        "jvm/mem/init": {
+            "description": "Initial memory", 
+            "prometheus_metric_name": "druid_jvm_mem_init", 
+            "labels": "[]", 
+            "type": "gauge"
+        },
+        "jvm/mem/max": {
+            "description": "Max memory", 
+            "prometheus_metric_name": "druid_jvm_mem_max", 
+            "labels": "[]", 
+            "type": "gauge"
+        },
+        "jvm/pool/max": {
+            "description": "Max pool", 
+            "prometheus_metric_name": "druid_jvm_pool_max", 
+            "labels": "[]", 
+            "type": "gauge"
+        },
+        "jvm/pool/committed": {
+            "description": "Committed pool", 
+            "prometheus_metric_name": "druid_jvm_pool_committed", 
+            "labels": "[]", 
+            "type": "gauge"
+        },
+        "jvm/pool/used": {
+            "description": "Pool used", 
+            "prometheus_metric_name": "druid_jvm_pool_used", 
+            "labels": "[]", 
+            "type": "gauge"
+        },
+        "jvm/pool/init": {
+            "description": "Initial pool", 
+            "prometheus_metric_name": "druid_jvm_pool_init", 
+            "labels": "[]", 
+            "type": "gauge"
+        },
+        "jvm/bufferpool/capacity": {
+            "description": "Bufferpool capacity", 
+            "prometheus_metric_name": "druid_jvm_bufferpool_capacity", 
+            "labels": "[]", 
+            "type": "gauge"
+        },
+        "jvm/bufferpool/used": {
+            "description": "Bufferpool used", 
+            "prometheus_metric_name": "druid_jvm_bufferpool_used", 
+            "labels": "[]", 
+            "type": "gauge"
+        },
+        "jvm/bufferpool/count": {
+            "description": "Bufferpool count", 
+            "prometheus_metric_name": "druid_jvm_bufferpool_count", 
+            "labels": "[]", 
+            "type": "gauge"
+        },
+        "jvm/gc/count": {
+            "description": "Garbage collection count", 
+            "prometheus_metric_name": "druid_jvm_gc_count", 
+            "labels": "[]", 
+            "type": "gauge"
+        },
+        "jvm/gc/cpu": {
+            "buckets": [
+                "10", 
+                "100", 
+                "500", 
+                "1000", 
+                "2000", 
+                "3000", 
+                "5000", 
+                "7000", 
+                "10000", 
+                "inf", 
+                "sum"
+            ], 
+            "description": "Count of CPU time in Nanoseconds spent on garbage collection Note: jvm/gc/cpu represents the total time over multiple GC cycles; divide by jvm/gc/count to get the mean GC time per cycle", 
+            "prometheus_metric_name": "druid_jvm_gc_cpu", 
+            "labels": "[]", 
+            "type": "histogram"
+        },
+        "jvm/gc/mem/max": {
+            "description": "druid_jvm_gc_mem_max", 
+            "prometheus_metric_name": "druid_jvm_gc_mem_max", 
+            "labels": "[]", 
+            "type": "gauge"
+        },
+        "jvm/gc/mem/capacity": {
+            "description": "druid_jvm_gc_mem_capacity", 
+            "prometheus_metric_name": "druid_jvm_gc_mem_capacity", 
+            "labels": "[]", 
+            "type": "gauge"
+        },
+        "jvm/gc/mem/used": {
+            "description": "druid_jvm_gc_mem_used", 
+            "prometheus_metric_name": "druid_jvm_gc_mem_used", 
+            "labels": "[]", 
+            "type": "gauge"
+        },
+        "jvm/gc/mem/init": {
+            "description": "druid_jvm_gc_mem_init", 
+            "prometheus_metric_name": "druid_jvm_gc_mem_init", 
+            "labels": "[]", 
+            "type": "gauge"
+        }
+    },
+    "broker": {
+        "namespace/cache/heapSizeInBytes": {
+            "description": "druid_namespace_cache_heapSizeInBytes", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_namespace_cache_heapSizeInBytes", 
+            "type": "gauge"
+        },
+        "jvm/gc/mem/init": {
+            "description": "druid_jvm_gc_mem_init", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_jvm_gc_mem_init", 
+            "type": "gauge"
+        },
+        "jvm/gc/mem/capacity": {
+            "description": "druid_jvm_gc_mem_capacity", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_jvm_gc_mem_capacity", 
+            "type": "gauge"
+        },
+        "jvm/gc/mem/max": {
+            "description": "druid_jvm_gc_mem_max", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_jvm_gc_mem_max", 
+            "type": "gauge"
+        },    
+        "jvm/gc/cpu": {
+            "buckets": [
+                "10", 
+                "100", 
+                "500", 
+                "1000", 
+                "2000", 
+                "3000", 
+                "5000", 
+                "7000", 
+                "10000", 
+                "inf", 
+                "sum"
+            ], 
+            "description": "Count of CPU time in Nanoseconds spent on garbage collection. Note: jvm/gc/cpu represents the total time over multiple GC cycles; divide by jvm/gc/count to get the mean GC time per cycle", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_jvm_gc_cpu", 
+            "type": "histogram"
+        },    
+        "jvm/gc/count": {
+            "description": "Garbage collection count.", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_jvm_gc_count", 
+            "type": "gauge"
+        },
+        "jvm/bufferpool/count": {
+            "description": "Bufferpool count.", 
+            "labels": "bufferpoolName", 
+            "prometheus_metric_name": "druid_jvm_bufferpool_count", 
+            "type": "gauge"
+        },
+        "jvm/bufferpool/used": {
+            "description": "Bufferpool used.", 
+            "labels": "bufferpoolName", 
+            "prometheus_metric_name": "druid_jvm_bufferpool_used", 
+            "type": "gauge"
+        },
+        "jvm/bufferpool/capacity": {
+            "description": "Bufferpool capacity.", 
+            "labels": "bufferpoolName", 
+            "prometheus_metric_name": "druid_jvm_bufferpool_capacity", 
+            "type": "gauge"
+        },
+        "jvm/pool/init": {
+            "description": "Initial pool.", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_jvm_pool_init", 
+            "type": "gauge"
+        },    
+        "jvm/pool/used": {
+            "description": "Pool used.", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_jvm_pool_used", 
+            "type": "gauge"
+        },    
+        "jvm/pool/committed": {
+            "description": "Committed pool.", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_jvm_pool_committed", 
+            "type": "gauge"
+        },    
+        "jvm/pool/max": {
+            "description": "Max pool.", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_jvm_pool_max", 
+            "type": "gauge"
+        },    
+        "jvm/mem/init": {
+            "description": "Initial memory.", 
+            "labels": "memKind", 
+            "prometheus_metric_name": "druid_jvm_mem_init", 
+            "type": "gauge"
+        },    
+        "jvm/mem/used": {
+            "description": "Used memory.", 
+            "labels": "memKind", 
+            "prometheus_metric_name": "druid_jvm_mem_used", 
+            "type": "gauge"
+        },    
+        "jvm/mem/committed": {
+            "description": "Committed memory.", 
+            "labels": "memKind", 
+            "prometheus_metric_name": "druid_jvm_mem_committed", 
+            "type": "gauge"
+        },    
+        "jvm/mem/max": {
+            "description": "Max memory.", 
+            "labels": "memKind", 
+            "prometheus_metric_name": "druid_jvm_mem_max", 
+            "type": "gauge"
+        },    
+        "jetty/numOpenConnections": {
+            "description": "Number of open jetty connections.", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_jetty_numOpenConnections", 
+            "type": "gauge"
+        },
+        "query/cpu/time": {
+            "buckets": [
+                "10", 
+                "100", 
+                "500", 
+                "1000", 
+                "2000", 
+                "3000", 
+                "5000", 
+                "7000", 
+                "10000", 
+                "inf", 
+                "sum"
+            ], 
+            "description": "Microseconds of CPU time taken to complete a query", 
+            "labels": "dataSource", 
+            "prometheus_metric_name": "druid_query_cpu_time", 
+            "type": "histogram"
+        },
+        "query/node/ttfb": {
+            "description": "Time to first byte. Milliseconds elapsed until Broker starts receiving the response from individual historical/realtime processes.", 
+            "labels": "dataSource", 
+            "prometheus_metric_name": "druid_query_node_ttfb", 
+            "type": "gauge"
+        },    
+        "query/node/bytes": {
+            "buckets": [
+                "10", 
+                "100", 
+                "500", 
+                "1000", 
+                "2000", 
+                "3000", 
+                "5000", 
+                "7000", 
+                "10000", 
+                "inf", 
+                "sum"
+            ], 
+            "description": "number of bytes returned from querying individual historical/realtime processes.", 
+            "labels": "dataSource", 
+            "prometheus_metric_name": "druid_query_node_bytes", 
+            "type": "histogram"
+        },      
+        "query/node/time": {
+            "buckets": [
+                "10", 
+                "100", 
+                "500", 
+                "1000", 
+                "2000", 
+                "3000", 
+                "5000", 
+                "7000", 
+                "10000", 
+                "inf", 
+                "sum"
+            ], 
+            "description": "Milliseconds taken to query individual historical/realtime processes.", 
+            "labels": "dataSource", 
+            "prometheus_metric_name": "druid_query_node_time", 
+            "type": "histogram"
+        },    
+        "jvm/heapAlloc/bytes": {
+            "buckets": [
+                "10", 
+                "100", 
+                "500", 
+                "1000", 
+                "2000", 
+                "3000", 
+                "5000", 
+                "7000", 
+                "10000", 
+                "inf", 
+                "sum"
+            ], 
+            "description": "druid_jvm_heapAlloc_bytes", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_jvm_heapAlloc_bytes", 
+            "type": "histogram"
+        },    
+        "query/time": {
+            "prometheus_metric_name": "druid_broker_query_time_ms",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Milliseconds taken to complete a query."
+        },
+        "query/bytes": {
+            "druid_metric_name": "query/bytes",
+            "prometheus_metric_name": "druid_broker_query_bytes",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Number of bytes returned in query response."
+        },
+        "sqlQuery/time": {
+            "buckets": [
+                "10", 
+                "100", 
+                "500", 
+                "1000", 
+                "2000", 
+                "3000", 
+                "5000", 
+                "7000", 
+                "10000", 
+                "inf", 
+                "sum"
+            ], 
+            "description": "Milliseconds taken to complete a SQL.", 
+            "labels": "dataSource", 
+            "prometheus_metric_name": "druid_sqlQuery_time", 
+            "type": "histogram"
+        },
+        "sqlQuery/bytes": {
+            "buckets": [
+                "10", 
+                "100", 
+                "500", 
+                "1000", 
+                "2000", 
+                "3000", 
+                "5000", 
+                "7000", 
+                "10000", 
+                "inf", 
+                "sum"
+            ], 
+            "description": "number of bytes returned in SQL response.", 
+            "labels": "dataSource", 
+            "prometheus_metric_name": "druid_sqlQuery_bytes", 
+            "type": "histogram"
+        },
+        "namespace/cache/numEntries": {
+            "description": "druid_namespace_cache_numEntries", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_namespace_cache_numEntries", 
+            "type": "gauge"
+        },
+        "namespace/deltaTasksStarted": {
+            "description": "druid_namespace_deltaTasksStarted", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_namespace_deltaTasksStarted", 
+            "type": "gauge"
+        },
+        "query/cache/total/numEntries": {
+            "prometheus_metric_name": "druid_broker_query_cache_numentries_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache entries."
+        },
+        "query/cache/total/sizeBytes": {
+            "prometheus_metric_name": "druid_broker_query_cache_size_bytes",
+            "daemon": "broker",
+            "type": "gauge",
+            "labels": [],
+            "description": "Size in bytes of cache entries."
+        },
+        "query/cache/total/hits": {
+            "prometheus_metric_name": "druid_broker_query_cache_hits_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache hits."
+        },
+        "query/cache/total/misses": {
+            "prometheus_metric_name": "druid_broker_query_cache_misses_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache misses."
+        },
+        "query/cache/total/evictions": {
+            "prometheus_metric_name": "druid_broker_query_cache_evictions_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache evictions."
+        },
+        "query/cache/total/timeouts": {
+            "prometheus_metric_name": "druid_broker_query_cache_timeouts_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache timeouts."
+        },
+        "query/cache/total/errors": {
+            "prometheus_metric_name": "druid_broker_query_cache_errors_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache errors."
+        },
+        "query/count": {
+            "prometheus_metric_name": "druid_broker_query_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of queries."
+        },
+        "query/success/count": {
+            "prometheus_metric_name": "druid_broker_success_query_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of Successfull queries."
+        },
+        "query/failed/count": {
+            "prometheus_metric_name": "druid_broker_failed_query_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of failed queries."
+        },
+        "query/interrupted/count": {
+            "prometheus_metric_name": "druid_broker_interrupted_query_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of interrupted queries."
+        }
+    },
+    "historical": {
+        "query/time": {
+            "prometheus_metric_name": "druid_historical_query_time_ms",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Milliseconds taken to complete a query."
+        },
+        "query/bytes": {
+            "prometheus_metric_name": "druid_historical_query_bytes",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Number of bytes returned in query response."
+        },
+        "segment/max": {
+            "prometheus_metric_name": "druid_historical_max_segment_bytes",
+            "type": "gauge",
+            "labels": [],
+            "description": "Maximum byte limit available for segments."
+        },
+        "segment/count": {
+            "prometheus_metric_name": "druid_historical_segment_count",
+            "type": "gauge",
+            "labels": [
+                "tier",
+                "dataSource"
+            ],
+            "description": "Number of served segments."
+        },
+        "segment/used": {
+            "prometheus_metric_name": "druid_historical_segment_used_bytes",
+            "type": "gauge",
+            "labels": [
+                "tier",
+                "dataSource"
+            ],
+            "description": "Bytes used for served segments."
+        },
+        "segment/scan/pending": {
+            "prometheus_metric_name": "druid_historical_segment_scan_pending",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of segments in queue waiting to be scanned."
+        },
+        "query/cache/total/numEntries": {
+            "prometheus_metric_name": "druid_historical_query_cache_numentries_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache entries."
+        },
+        "query/cache/total/sizeBytes": {
+            "prometheus_metric_name": "druid_historical_query_cache_size_bytes",
+            "type": "gauge",
+            "labels": [],
+            "description": "Size in bytes of cache entries."
+        },
+        "query/cache/total/hits": {
+            "prometheus_metric_name": "druid_historical_query_cache_hits_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache hits."
+        },
+        "query/cache/total/misses": {
+            "prometheus_metric_name": "druid_historical_query_cache_misses_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache misses."
+        },
+        "query/cache/total/evictions": {
+            "prometheus_metric_name": "druid_historical_query_cache_evictions_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache evictions."
+        },
+        "query/cache/total/timeouts": {
+            "prometheus_metric_name": "druid_historical_query_cache_timeouts_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache timeouts."
+        },
+        "query/cache/total/errors": {
+            "prometheus_metric_name": "druid_historical_query_cache_errors_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache errors."
+        },
+        "query/count": {
+            "prometheus_metric_name": "druid_historical_query_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of queries."
+        },
+        "query/success/count": {
+            "prometheus_metric_name": "druid_historical_success_query_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of Successfull queries."
+        },
+        "query/failed/count": {
+            "prometheus_metric_name": "druid_historical_failed_query_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of failed queries."
+        },
+        "query/interrupted/count": {
+            "prometheus_metric_name": "druid_historical_interrupted_query_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of interrupted queries."
+        }
+    },
+    "middlemanager": {
+        "query/time": {
+            "prometheus_metric_name": "druid_middlemanager_query_time_ms",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Milliseconds taken to complete a query."
+        },
+        "query/bytes": {
+            "druid_metric_name": "query/bytes",
+            "prometheus_metric_name": "druid_middlemanager_query_bytes",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Number of bytes returned in query response."
+        },
+        "ingest/events/thrownAway": {
+            "prometheus_metric_name": "druid_realtime_ingest_events_thrown_away_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Number of events rejected because they are outside the windowPeriod."
+        },
+        "ingest/events/unparseable": {
+            "prometheus_metric_name": "druid_realtime_ingest_events_unparseable_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Number of events rejected because the events are unparseable."
+        },
+        "ingest/events/duplicate": {
+            "prometheus_metric_name": "druid_realtime_ingest_events_duplicate_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Number of events rejected because the events are duplicated."
+        },
+        "ingest/events/processed": {
+            "prometheus_metric_name": "druid_realtime_ingest_events_processed_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Number of events successfully processed per emission period."
+        },
+        "ingest/rows/output": {
+            "prometheus_metric_name": "druid_realtime_ingest_rows_output_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Number of Druid rows persisted."
+        },
+        "ingest/persists/count": {
+            "prometheus_metric_name": "druid_realtime_ingest_persists_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Number of events successfully persisted."
+        },
+        "ingest/persists/time": {
+            "prometheus_metric_name": "druid_realtime_ingest_persists_time",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Milliseconds spent doing intermediate persist."
+        },
+        "ingest/persists/cpu": {
+            "prometheus_metric_name": "druid_realtime_ingest_persists_cpu",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Cpu time in Nanoseconds spent on doing intermediate persist."
+        },
+        "ingest/persists/backPressure": {
+            "prometheus_metric_name": "druid_realtime_ingest_persists_backpressure",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Milliseconds spent creating persist tasks and blocking waiting for them to finish."
+        },
+        "ingest/persists/failed": {
+            "prometheus_metric_name": "druid_realtime_ingest_persists_failed_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Number of times persist failed."
+        },
+        "ingest/handoff/failed": {
+            "prometheus_metric_name": "druid_realtime_ingest_handoff_failed_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Number of times handoff failed."
+        },
+        "ingest/handoff/count": {
+            "prometheus_metric_name": "druid_realtime_ingest_handoff_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Number of times handoff has happened."
+        },
+        "ingest/merge/time": {
+            "prometheus_metric_name": "druid_realtime_ingest_merge_time",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Milliseconds spent merging intermediate segments."
+        },
+        "ingest/merge/cpu": {
+            "prometheus_metric_name": "druid_realtime_ingest_merge_cpu",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Cpu time in Nanoseconds spent on merging intermediate segments."
+        },
+        "ingest/sink/count": {
+            "prometheus_metric_name": "druid_realtime_ingest_sink_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Number of sinks not handoffed."
+        },
+        "ingest/events/messageGap": {
+            "prometheus_metric_name": "druid_realtime_ingest_events_messagegap",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Time gap between the data time in event and current system time."
+        }
+    },
+    "coordinator": {
+        "segment/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Number of served segments."
+        },
+        "segment/assigned/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_assigned_count",
+            "type": "gauge",
+            "labels": [
+                "tier"
+            ],
+            "description": "Number of segments assigned to be loaded in the cluster."
+        },
+        "segment/moved/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_moved_count",
+            "type": "gauge",
+            "labels": [
+                "tier"
+            ],
+            "description": "Number of segments assigned to be loaded in the cluster."
+        },
+        "segment/dropped/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_dropped_count",
+            "type": "gauge",
+            "labels": [
+                "tier"
+            ],
+            "description": "Number of segments dropped due to being overshadowed."
+        },
+        "segment/deleted/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_deleted_count",
+            "type": "gauge",
+            "labels": [
+                "tier"
+            ],
+            "description": "Number of segments dropped due to rules."
+        },
+        "segment/unneeded/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_unneeded_count",
+            "type": "gauge",
+            "labels": [
+                "tier"
+            ],
+            "description": "Number of segments dropped due to being marked as unused."
+        },
+        "segment/overShadowed/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_overshadowed_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of overShadowed segments."
+        },
+        "segment/loadQueue/size": {
+            "prometheus_metric_name": "druid_coordinator_segment_loadqueue_size_bytes",
+            "type": "gauge",
+            "labels": [
+                "server"
+            ],
+            "description": "Size in bytes of segments to load."
+        },
+        "segment/loadQueue/failed": {
+            "prometheus_metric_name": "druid_coordinator_segment_loadqueue_failed_count",
+            "type": "gauge",
+            "labels": [
+                "server"
+            ],
+            "description": "Number of segments that failed to load."
+        },
+        "segment/loadQueue/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_loadqueue_count",
+            "type": "gauge",
+            "labels": [
+                "server"
+            ],
+            "description": "Number of segments to load."
+        },
+        "segment/dropQueue/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_dropqueue_count",
+            "type": "gauge",
+            "labels": [
+                "server"
+            ],
+            "description": "Number of segments to drop."
+        },
+        "segment/size": {
+            "prometheus_metric_name": "druid_coordinator_segment_size_bytes",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Size in bytes of available segments."
+        },
+        "segment/unavailable/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_unavailable_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Number of segments (not including replicas) left to load until segments that should be loaded in the cluster are available for queries."
+        },
+        "segment/underReplicated/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_under_replicated_count",
+            "type": "gauge",
+            "labels": [
+                "tier",
+                "dataSource"
+            ],
+            "description": "Number of segments (including replicas) left to load until segments that should be loaded in the cluster are available for queries."
+        },
+        "tier/historical/count": {
+            "prometheus_metric_name": "druid_coordinator_tier_historical_count",
+            "type": "gauge",
+            "labels": [
+                "tier"
+            ],
+            "description": "Number of available historical nodes in each tier."
+        },
+        "tier/replication/factor": {
+            "prometheus_metric_name": "druid_coordinator_tier_replication_count",
+            "type": "gauge",
+            "labels": [
+                "tier"
+            ],
+            "description": "Configured maximum replication factor in each tier."
+        },
+        "tier/required/capacity": {
+            "prometheus_metric_name": "druid_coordinator_tier_required_capacity_bytes",
+            "type": "gauge",
+            "labels": [
+                "tier"
+            ],
+            "description": "Total capacity in bytes required in each tier."
+        },
+        "tier/total/capacity": {
+            "prometheus_metric_name": "druid_coordinator_tier_total_capacity_bytes",
+            "type": "gauge",
+            "labels": [
+                "tier"
+            ],
+            "description": "Total capacity in bytes available in each tier."
+        },
+        "ingest/kafka/lag": {
+            "prometheus_metric_name": "druid_realtime_ingest_kafka_lag",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Total lag between the offsets consumed by the Kafka indexing tasks and latest offsets in Kafka brokers across all partitions."
+        },
+        "ingest/kafka/maxLag": {
+            "prometheus_metric_name": "druid_realtime_ingest_kafka_maxlag",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Max lag between the offsets consumed by the Kafka indexing tasks and latest offsets in Kafka brokers across all partitions."
+        },
+        "ingest/kafka/avgLag": {
+            "prometheus_metric_name": "druid_realtime_ingest_kafka_avglag",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Average lag between the offsets consumed by the Kafka indexing tasks and latest offsets in Kafka brokers across all partitions."
+        },
+        "task/success/count": {
+            "prometheus_metric_name": "druid_coordinator_task_success_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Number of successful tasks per emission period."
+        },
+        "task/failed/count": {
+            "prometheus_metric_name": "druid_coordinator_task_failed_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Number of failed tasks per emission period."
+        },
+        "task/running/count": {
+            "prometheus_metric_name": "druid_coordinator_task_running_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Number of current running tasks."
+        },
+        "task/pending/count": {
+            "prometheus_metric_name": "druid_coordinator_task_pending_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Number of current pending tasks."
+        },
+        "task/waiting/count": {
+            "prometheus_metric_name": "druid_coordinator_task_waiting_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Number of current waiting tasks."
+        },
+        "task/run/time": {
+            "prometheus_metric_name": "druid_coordinator_task_run_time",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Milliseconds taken to run a task."
+        },
+        "task/action/log/time": {
+            "prometheus_metric_name": "druid_coordinator_task_action_log_time",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Milliseconds taken to log a task action to the audit log."
+        },
+        "task/action/run/time": {
+            "prometheus_metric_name": "druid_coordinator_task_action_run_time",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Milliseconds taken to execute a task action."
+        }
+    }
+}

--- a/conf/druid_0_18_0.json
+++ b/conf/druid_0_18_0.json
@@ -1,0 +1,894 @@
+{
+    "router": {
+        "query/time": {
+            "buckets": [
+                "10", 
+                "100", 
+                "500", 
+                "1000", 
+                "2000", 
+                "3000", 
+                "5000", 
+                "7000", 
+                "10000", 
+                "inf", 
+                "sum"
+            ], 
+            "description": "Milliseconds taken to complete a query", 
+            "labels": "dataSource", 
+            "prometheus_metric_name": "druid_query_time", 
+            "type": "histogram"
+        },
+        "jvm/mem/committed": {
+            "description": "Committed memory", 
+            "prometheus_metric_name": "druid_jvm_mem_committed", 
+            "type": "gauge"
+        },
+        "jvm/mem/used": {
+            "description": "Used memory", 
+            "prometheus_metric_name": "druid_jvm_mem_used", 
+            "type": "gauge"
+        },
+        "jvm/mem/init": {
+            "description": "Initial memory", 
+            "prometheus_metric_name": "druid_jvm_mem_init", 
+            "type": "gauge"
+        },
+        "jvm/mem/max": {
+            "description": "Max memory", 
+            "prometheus_metric_name": "druid_jvm_mem_max", 
+            "type": "gauge"
+        },
+        "jvm/pool/max": {
+            "description": "Max pool", 
+            "prometheus_metric_name": "druid_jvm_pool_max", 
+            "type": "gauge"
+        },
+        "jvm/pool/committed": {
+            "description": "Committed pool", 
+            "prometheus_metric_name": "druid_jvm_pool_committed", 
+            "type": "gauge"
+        },
+        "jvm/pool/used": {
+            "description": "Pool used", 
+            "prometheus_metric_name": "druid_jvm_pool_used", 
+            "type": "gauge"
+        },
+        "jvm/pool/init": {
+            "description": "Initial pool", 
+            "prometheus_metric_name": "druid_jvm_pool_init", 
+            "type": "gauge"
+        },
+        "jvm/bufferpool/capacity": {
+            "description": "Bufferpool capacity", 
+            "prometheus_metric_name": "druid_jvm_bufferpool_capacity", 
+            "type": "gauge"
+        },
+        "jvm/bufferpool/used": {
+            "description": "Bufferpool used", 
+            "prometheus_metric_name": "druid_jvm_bufferpool_used", 
+            "type": "gauge"
+        },
+        "jvm/bufferpool/count": {
+            "description": "Bufferpool count", 
+            "prometheus_metric_name": "druid_jvm_bufferpool_count", 
+            "type": "gauge"
+        },
+        "jvm/gc/count": {
+            "description": "Garbage collection count", 
+            "prometheus_metric_name": "druid_jvm_gc_count", 
+            "type": "gauge"
+        },
+        "jvm/gc/cpu": {
+            "buckets": [
+                "10", 
+                "100", 
+                "500", 
+                "1000", 
+                "2000", 
+                "3000", 
+                "5000", 
+                "7000", 
+                "10000", 
+                "inf", 
+                "sum"
+            ], 
+            "description": "Count of CPU time in Nanoseconds spent on garbage collection Note: jvm/gc/cpu represents the total time over multiple GC cycles; divide by jvm/gc/count to get the mean GC time per cycle", 
+            "prometheus_metric_name": "druid_jvm_gc_cpu", 
+            "type": "histogram"
+        },
+        "jvm/gc/mem/max": {
+            "description": "druid_jvm_gc_mem_max", 
+            "prometheus_metric_name": "druid_jvm_gc_mem_max", 
+            "type": "gauge"
+        },
+        "jvm/gc/mem/capacity": {
+            "description": "druid_jvm_gc_mem_capacity", 
+            "prometheus_metric_name": "druid_jvm_gc_mem_capacity", 
+            "type": "gauge"
+        },
+        "jvm/gc/mem/used": {
+            "description": "druid_jvm_gc_mem_used", 
+            "prometheus_metric_name": "druid_jvm_gc_mem_used", 
+            "type": "gauge"
+        },
+        "jvm/gc/mem/init": {
+            "description": "druid_jvm_gc_mem_init", 
+            "prometheus_metric_name": "druid_jvm_gc_mem_init", 
+            "type": "gauge"
+        }
+    },
+    "broker": {
+        "query/time": {
+            "prometheus_metric_name": "druid_broker_query_time_ms",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Milliseconds taken to complete a query."
+        },
+        "query/bytes": {
+            "druid_metric_name": "query/bytes",
+            "prometheus_metric_name": "druid_broker_query_bytes",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Number of bytes returned in query response."
+        },
+        "query/cache/total/numEntries": {
+            "prometheus_metric_name": "druid_broker_query_cache_numentries_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache entries."
+        },
+        "query/cache/total/sizeBytes": {
+            "prometheus_metric_name": "druid_broker_query_cache_size_bytes",
+            "daemon": "broker",
+            "type": "gauge",
+            "labels": [],
+            "description": "Size in bytes of cache entries."
+        },
+        "query/cache/total/hits": {
+            "prometheus_metric_name": "druid_broker_query_cache_hits_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache hits."
+        },
+        "query/cache/total/misses": {
+            "prometheus_metric_name": "druid_broker_query_cache_misses_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache misses."
+        },
+        "query/cache/total/evictions": {
+            "prometheus_metric_name": "druid_broker_query_cache_evictions_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache evictions."
+        },
+        "query/cache/total/timeouts": {
+            "prometheus_metric_name": "druid_broker_query_cache_timeouts_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache timeouts."
+        },
+        "query/cache/total/errors": {
+            "prometheus_metric_name": "druid_broker_query_cache_errors_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache errors."
+        },
+        "query/count": {
+            "prometheus_metric_name": "druid_broker_query_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of queries."
+        },
+        "query/success/count": {
+            "prometheus_metric_name": "druid_broker_success_query_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of Successfull queries."
+        },
+        "query/failed/count": {
+            "prometheus_metric_name": "druid_broker_failed_query_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of failed queries."
+        },
+        "query/interrupted/count": {
+            "prometheus_metric_name": "druid_broker_interrupted_query_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of interrupted queries."
+        }
+    },
+    "historical": {
+        "query/time": {
+            "prometheus_metric_name": "druid_historical_query_time_ms",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Milliseconds taken to complete a query."
+        },
+        "query/bytes": {
+            "prometheus_metric_name": "druid_historical_query_bytes",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Number of bytes returned in query response."
+        },
+        "segment/max": {
+            "prometheus_metric_name": "druid_historical_max_segment_bytes",
+            "type": "gauge",
+            "labels": [],
+            "description": "Maximum byte limit available for segments."
+        },
+        "segment/count": {
+            "prometheus_metric_name": "druid_historical_segment_count",
+            "type": "gauge",
+            "labels": [
+                "tier",
+                "dataSource"
+            ],
+            "description": "Number of served segments."
+        },
+        "segment/used": {
+            "prometheus_metric_name": "druid_historical_segment_used_bytes",
+            "type": "gauge",
+            "labels": [
+                "tier",
+                "dataSource"
+            ],
+            "description": "Bytes used for served segments."
+        },
+        "segment/scan/pending": {
+            "prometheus_metric_name": "druid_historical_segment_scan_pending",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of segments in queue waiting to be scanned."
+        },
+        "query/cache/total/numEntries": {
+            "prometheus_metric_name": "druid_historical_query_cache_numentries_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache entries."
+        },
+        "query/cache/total/sizeBytes": {
+            "prometheus_metric_name": "druid_historical_query_cache_size_bytes",
+            "type": "gauge",
+            "labels": [],
+            "description": "Size in bytes of cache entries."
+        },
+        "query/cache/total/hits": {
+            "prometheus_metric_name": "druid_historical_query_cache_hits_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache hits."
+        },
+        "query/cache/total/misses": {
+            "prometheus_metric_name": "druid_historical_query_cache_misses_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache misses."
+        },
+        "query/cache/total/evictions": {
+            "prometheus_metric_name": "druid_historical_query_cache_evictions_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache evictions."
+        },
+        "query/cache/total/timeouts": {
+            "prometheus_metric_name": "druid_historical_query_cache_timeouts_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache timeouts."
+        },
+        "query/cache/total/errors": {
+            "prometheus_metric_name": "druid_historical_query_cache_errors_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of cache errors."
+        },
+        "query/count": {
+            "prometheus_metric_name": "druid_historical_query_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of queries."
+        },
+        "query/success/count": {
+            "prometheus_metric_name": "druid_historical_success_query_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of Successfull queries."
+        },
+        "query/failed/count": {
+            "prometheus_metric_name": "druid_historical_failed_query_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of failed queries."
+        },
+        "query/interrupted/count": {
+            "prometheus_metric_name": "druid_historical_interrupted_query_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of interrupted queries."
+        }
+    },
+    "middlemanager": {
+        "query/time": {
+            "prometheus_metric_name": "druid_middlemanager_query_time_ms",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Milliseconds taken to complete a query."
+        },
+        "query/bytes": {
+            "druid_metric_name": "query/bytes",
+            "prometheus_metric_name": "druid_middlemanager_query_bytes",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Number of bytes returned in query response."
+        },
+        "ingest/events/thrownAway": {
+            "prometheus_metric_name": "druid_realtime_ingest_events_thrown_away_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Number of events rejected because they are outside the windowPeriod."
+        },
+        "ingest/events/unparseable": {
+            "prometheus_metric_name": "druid_realtime_ingest_events_unparseable_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Number of events rejected because the events are unparseable."
+        },
+        "ingest/events/duplicate": {
+            "prometheus_metric_name": "druid_realtime_ingest_events_duplicate_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Number of events rejected because the events are duplicated."
+        },
+        "ingest/events/processed": {
+            "prometheus_metric_name": "druid_realtime_ingest_events_processed_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Number of events successfully processed per emission period."
+        },
+        "ingest/rows/output": {
+            "prometheus_metric_name": "druid_realtime_ingest_rows_output_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Number of Druid rows persisted."
+        },
+        "ingest/persists/count": {
+            "prometheus_metric_name": "druid_realtime_ingest_persists_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Number of events successfully persisted."
+        },
+        "ingest/persists/time": {
+            "prometheus_metric_name": "druid_realtime_ingest_persists_time",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Milliseconds spent doing intermediate persist."
+        },
+        "ingest/persists/cpu": {
+            "prometheus_metric_name": "druid_realtime_ingest_persists_cpu",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Cpu time in Nanoseconds spent on doing intermediate persist."
+        },
+        "ingest/persists/backPressure": {
+            "prometheus_metric_name": "druid_realtime_ingest_persists_backpressure",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Milliseconds spent creating persist tasks and blocking waiting for them to finish."
+        },
+        "ingest/persists/failed": {
+            "prometheus_metric_name": "druid_realtime_ingest_persists_failed_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Number of times persist failed."
+        },
+        "ingest/handoff/failed": {
+            "prometheus_metric_name": "druid_realtime_ingest_handoff_failed_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Number of times handoff failed."
+        },
+        "ingest/handoff/count": {
+            "prometheus_metric_name": "druid_realtime_ingest_handoff_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Number of times handoff has happened."
+        },
+        "ingest/merge/time": {
+            "prometheus_metric_name": "druid_realtime_ingest_merge_time",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Milliseconds spent merging intermediate segments."
+        },
+        "ingest/merge/cpu": {
+            "prometheus_metric_name": "druid_realtime_ingest_merge_cpu",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Cpu time in Nanoseconds spent on merging intermediate segments."
+        },
+        "ingest/sink/count": {
+            "prometheus_metric_name": "druid_realtime_ingest_sink_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Number of sinks not handoffed."
+        },
+        "ingest/events/messageGap": {
+            "prometheus_metric_name": "druid_realtime_ingest_events_messagegap",
+            "type": "gauge",
+            "labels": [
+                "dataSource",
+                "taskId"
+            ],
+            "description": "Time gap between the data time in event and current system time."
+        }
+    },
+    "coordinator": {
+        "segment/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Number of served segments."
+        },
+        "segment/assigned/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_assigned_count",
+            "type": "gauge",
+            "labels": [
+                "tier"
+            ],
+            "description": "Number of segments assigned to be loaded in the cluster."
+        },
+        "segment/moved/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_moved_count",
+            "type": "gauge",
+            "labels": [
+                "tier"
+            ],
+            "description": "Number of segments assigned to be loaded in the cluster."
+        },
+        "segment/dropped/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_dropped_count",
+            "type": "gauge",
+            "labels": [
+                "tier"
+            ],
+            "description": "Number of segments dropped due to being overshadowed."
+        },
+        "segment/deleted/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_deleted_count",
+            "type": "gauge",
+            "labels": [
+                "tier"
+            ],
+            "description": "Number of segments dropped due to rules."
+        },
+        "segment/unneeded/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_unneeded_count",
+            "type": "gauge",
+            "labels": [
+                "tier"
+            ],
+            "description": "Number of segments dropped due to being marked as unused."
+        },
+        "segment/overShadowed/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_overshadowed_count",
+            "type": "gauge",
+            "labels": [],
+            "description": "Number of overShadowed segments."
+        },
+        "segment/loadQueue/size": {
+            "prometheus_metric_name": "druid_coordinator_segment_loadqueue_size_bytes",
+            "type": "gauge",
+            "labels": [
+                "server"
+            ],
+            "description": "Size in bytes of segments to load."
+        },
+        "segment/loadQueue/failed": {
+            "prometheus_metric_name": "druid_coordinator_segment_loadqueue_failed_count",
+            "type": "gauge",
+            "labels": [
+                "server"
+            ],
+            "description": "Number of segments that failed to load."
+        },
+        "segment/loadQueue/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_loadqueue_count",
+            "type": "gauge",
+            "labels": [
+                "server"
+            ],
+            "description": "Number of segments to load."
+        },
+        "segment/dropQueue/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_dropqueue_count",
+            "type": "gauge",
+            "labels": [
+                "server"
+            ],
+            "description": "Number of segments to drop."
+        },
+        "segment/size": {
+            "prometheus_metric_name": "druid_coordinator_segment_size_bytes",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Size in bytes of available segments."
+        },
+        "segment/unavailable/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_unavailable_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Number of segments (not including replicas) left to load until segments that should be loaded in the cluster are available for queries."
+        },
+        "segment/underReplicated/count": {
+            "prometheus_metric_name": "druid_coordinator_segment_under_replicated_count",
+            "type": "gauge",
+            "labels": [
+                "tier",
+                "dataSource"
+            ],
+            "description": "Number of segments (including replicas) left to load until segments that should be loaded in the cluster are available for queries."
+        },
+        "tier/historical/count": {
+            "prometheus_metric_name": "druid_coordinator_tier_historical_count",
+            "type": "gauge",
+            "labels": [
+                "tier"
+            ],
+            "description": "Number of available historical nodes in each tier."
+        },
+        "tier/replication/factor": {
+            "prometheus_metric_name": "druid_coordinator_tier_replication_count",
+            "type": "gauge",
+            "labels": [
+                "tier"
+            ],
+            "description": "Configured maximum replication factor in each tier."
+        },
+        "tier/required/capacity": {
+            "prometheus_metric_name": "druid_coordinator_tier_required_capacity_bytes",
+            "type": "gauge",
+            "labels": [
+                "tier"
+            ],
+            "description": "Total capacity in bytes required in each tier."
+        },
+        "tier/total/capacity": {
+            "prometheus_metric_name": "druid_coordinator_tier_total_capacity_bytes",
+            "type": "gauge",
+            "labels": [
+                "tier"
+            ],
+            "description": "Total capacity in bytes available in each tier."
+        },
+        "ingest/kafka/lag": {
+            "prometheus_metric_name": "druid_realtime_ingest_kafka_lag",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Total lag between the offsets consumed by the Kafka indexing tasks and latest offsets in Kafka brokers across all partitions."
+        },
+        "ingest/kafka/maxLag": {
+            "prometheus_metric_name": "druid_realtime_ingest_kafka_maxlag",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Max lag between the offsets consumed by the Kafka indexing tasks and latest offsets in Kafka brokers across all partitions."
+        },
+        "ingest/kafka/avgLag": {
+            "prometheus_metric_name": "druid_realtime_ingest_kafka_avglag",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Average lag between the offsets consumed by the Kafka indexing tasks and latest offsets in Kafka brokers across all partitions."
+        },
+        "task/success/count": {
+            "prometheus_metric_name": "druid_coordinator_task_success_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Number of successful tasks per emission period."
+        },
+        "task/failed/count": {
+            "prometheus_metric_name": "druid_coordinator_task_failed_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Number of failed tasks per emission period."
+        },
+        "task/running/count": {
+            "prometheus_metric_name": "druid_coordinator_task_running_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Number of current running tasks."
+        },
+        "task/pending/count": {
+            "prometheus_metric_name": "druid_coordinator_task_pending_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Number of current pending tasks."
+        },
+        "task/waiting/count": {
+            "prometheus_metric_name": "druid_coordinator_task_waiting_count",
+            "type": "gauge",
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Number of current waiting tasks."
+        },
+        "task/run/time": {
+            "prometheus_metric_name": "druid_coordinator_task_run_time",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Milliseconds taken to run a task."
+        },
+        "task/action/log/time": {
+            "prometheus_metric_name": "druid_coordinator_task_action_log_time",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Milliseconds taken to log a task action to the audit log."
+        },
+        "task/action/run/time": {
+            "prometheus_metric_name": "druid_coordinator_task_action_run_time",
+            "type": "histogram",
+            "buckets": [
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
+                "sum"
+            ],
+            "labels": [
+                "dataSource"
+            ],
+            "description": "Milliseconds taken to execute a task action."
+        }
+    }
+}

--- a/conf/druid_0_18_0.json
+++ b/conf/druid_0_18_0.json
@@ -216,7 +216,19 @@
             "labels": "dataSource", 
             "prometheus_metric_name": "druid_sqlQuery_bytes", 
             "type": "histogram"
-        },    
+        },
+        "namespace/cache/numEntries": {
+            "description": "druid_namespace_cache_numEntries", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_namespace_cache_numEntries", 
+            "type": "gauge"
+        },
+        "namespace/deltaTasksStarted": {
+            "description": "druid_namespace_deltaTasksStarted", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_namespace_deltaTasksStarted", 
+            "type": "gauge"
+        },
         "query/cache/total/numEntries": {
             "prometheus_metric_name": "druid_broker_query_cache_numentries_count",
             "type": "gauge",

--- a/conf/druid_0_18_0.json
+++ b/conf/druid_0_18_0.json
@@ -1,5 +1,11 @@
 {
     "router": {
+        "jetty/numOpenConnections": {
+            "description": "Number of open jetty connections.", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_jetty_numOpenConnections", 
+            "type": "gauge"
+        },
         "query/time": {
             "buckets": [
                 "10", 
@@ -136,6 +142,191 @@
         }
     },
     "broker": {
+        "jvm/gc/mem/max": {
+            "description": "druid_jvm_gc_mem_max", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_jvm_gc_mem_max", 
+            "type": "gauge"
+        },    
+        "jvm/gc/cpu": {
+            "buckets": [
+                "10", 
+                "100", 
+                "500", 
+                "1000", 
+                "2000", 
+                "3000", 
+                "5000", 
+                "7000", 
+                "10000", 
+                "inf", 
+                "sum"
+            ], 
+            "description": "Count of CPU time in Nanoseconds spent on garbage collection. Note: jvm/gc/cpu represents the total time over multiple GC cycles; divide by jvm/gc/count to get the mean GC time per cycle", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_jvm_gc_cpu", 
+            "type": "histogram"
+        },    
+        "jvm/gc/count": {
+            "description": "Garbage collection count.", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_jvm_gc_count", 
+            "type": "gauge"
+        },
+        "jvm/bufferpool/count": {
+            "description": "Bufferpool count.", 
+            "labels": "bufferpoolName", 
+            "prometheus_metric_name": "druid_jvm_bufferpool_count", 
+            "type": "gauge"
+        },
+        "jvm/bufferpool/used": {
+            "description": "Bufferpool used.", 
+            "labels": "bufferpoolName", 
+            "prometheus_metric_name": "druid_jvm_bufferpool_used", 
+            "type": "gauge"
+        },
+        "jvm/bufferpool/capacity": {
+            "description": "Bufferpool capacity.", 
+            "labels": "bufferpoolName", 
+            "prometheus_metric_name": "druid_jvm_bufferpool_capacity", 
+            "type": "gauge"
+        },
+        "jvm/pool/init": {
+            "description": "Initial pool.", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_jvm_pool_init", 
+            "type": "gauge"
+        },    
+        "jvm/pool/used": {
+            "description": "Pool used.", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_jvm_pool_used", 
+            "type": "gauge"
+        },    
+        "jvm/pool/committed": {
+            "description": "Committed pool.", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_jvm_pool_committed", 
+            "type": "gauge"
+        },    
+        "jvm/pool/max": {
+            "description": "Max pool.", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_jvm_pool_max", 
+            "type": "gauge"
+        },    
+        "jvm/mem/init": {
+            "description": "Initial memory.", 
+            "labels": "memKind", 
+            "prometheus_metric_name": "druid_jvm_mem_init", 
+            "type": "gauge"
+        },    
+        "jvm/mem/used": {
+            "description": "Used memory.", 
+            "labels": "memKind", 
+            "prometheus_metric_name": "druid_jvm_mem_used", 
+            "type": "gauge"
+        },    
+        "jvm/mem/committed": {
+            "description": "Committed memory.", 
+            "labels": "memKind", 
+            "prometheus_metric_name": "druid_jvm_mem_committed", 
+            "type": "gauge"
+        },    
+        "jvm/mem/max": {
+            "description": "Max memory.", 
+            "labels": "memKind", 
+            "prometheus_metric_name": "druid_jvm_mem_max", 
+            "type": "gauge"
+        },    
+        "jetty/numOpenConnections": {
+            "description": "Number of open jetty connections.", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_jetty_numOpenConnections", 
+            "type": "gauge"
+        },
+        "query/cpu/time": {
+            "buckets": [
+                "10", 
+                "100", 
+                "500", 
+                "1000", 
+                "2000", 
+                "3000", 
+                "5000", 
+                "7000", 
+                "10000", 
+                "inf", 
+                "sum"
+            ], 
+            "description": "Microseconds of CPU time taken to complete a query", 
+            "labels": "dataSource", 
+            "prometheus_metric_name": "druid_query_cpu_time", 
+            "type": "histogram"
+        },
+        "query/node/ttfb": {
+            "description": "Time to first byte. Milliseconds elapsed until Broker starts receiving the response from individual historical/realtime processes.", 
+            "labels": "dataSource", 
+            "prometheus_metric_name": "druid_query_node_ttfb", 
+            "type": "gauge"
+        },    
+        "query/node/bytes": {
+            "buckets": [
+                "10", 
+                "100", 
+                "500", 
+                "1000", 
+                "2000", 
+                "3000", 
+                "5000", 
+                "7000", 
+                "10000", 
+                "inf", 
+                "sum"
+            ], 
+            "description": "number of bytes returned from querying individual historical/realtime processes.", 
+            "labels": "dataSource", 
+            "prometheus_metric_name": "druid_query_node_bytes", 
+            "type": "histogram"
+        },      
+        "query/node/time": {
+            "buckets": [
+                "10", 
+                "100", 
+                "500", 
+                "1000", 
+                "2000", 
+                "3000", 
+                "5000", 
+                "7000", 
+                "10000", 
+                "inf", 
+                "sum"
+            ], 
+            "description": "Milliseconds taken to query individual historical/realtime processes.", 
+            "labels": "dataSource", 
+            "prometheus_metric_name": "druid_query_node_time", 
+            "type": "histogram"
+        },    
+        "jvm/heapAlloc/bytes": {
+            "buckets": [
+                "10", 
+                "100", 
+                "500", 
+                "1000", 
+                "2000", 
+                "3000", 
+                "5000", 
+                "7000", 
+                "10000", 
+                "inf", 
+                "sum"
+            ], 
+            "description": "druid_jvm_heapAlloc_bytes", 
+            "labels": "[]", 
+            "prometheus_metric_name": "druid_jvm_heapAlloc_bytes", 
+            "type": "histogram"
+        },    
         "query/time": {
             "prometheus_metric_name": "druid_broker_query_time_ms",
             "type": "histogram",

--- a/conf/druid_0_18_0.json
+++ b/conf/druid_0_18_0.json
@@ -22,61 +22,73 @@
         "jvm/mem/committed": {
             "description": "Committed memory", 
             "prometheus_metric_name": "druid_jvm_mem_committed", 
+            "labels": "[]", 
             "type": "gauge"
         },
         "jvm/mem/used": {
             "description": "Used memory", 
             "prometheus_metric_name": "druid_jvm_mem_used", 
+            "labels": "[]", 
             "type": "gauge"
         },
         "jvm/mem/init": {
             "description": "Initial memory", 
             "prometheus_metric_name": "druid_jvm_mem_init", 
+            "labels": "[]", 
             "type": "gauge"
         },
         "jvm/mem/max": {
             "description": "Max memory", 
             "prometheus_metric_name": "druid_jvm_mem_max", 
+            "labels": "[]", 
             "type": "gauge"
         },
         "jvm/pool/max": {
             "description": "Max pool", 
             "prometheus_metric_name": "druid_jvm_pool_max", 
+            "labels": "[]", 
             "type": "gauge"
         },
         "jvm/pool/committed": {
             "description": "Committed pool", 
             "prometheus_metric_name": "druid_jvm_pool_committed", 
+            "labels": "[]", 
             "type": "gauge"
         },
         "jvm/pool/used": {
             "description": "Pool used", 
             "prometheus_metric_name": "druid_jvm_pool_used", 
+            "labels": "[]", 
             "type": "gauge"
         },
         "jvm/pool/init": {
             "description": "Initial pool", 
             "prometheus_metric_name": "druid_jvm_pool_init", 
+            "labels": "[]", 
             "type": "gauge"
         },
         "jvm/bufferpool/capacity": {
             "description": "Bufferpool capacity", 
             "prometheus_metric_name": "druid_jvm_bufferpool_capacity", 
+            "labels": "[]", 
             "type": "gauge"
         },
         "jvm/bufferpool/used": {
             "description": "Bufferpool used", 
             "prometheus_metric_name": "druid_jvm_bufferpool_used", 
+            "labels": "[]", 
             "type": "gauge"
         },
         "jvm/bufferpool/count": {
             "description": "Bufferpool count", 
             "prometheus_metric_name": "druid_jvm_bufferpool_count", 
+            "labels": "[]", 
             "type": "gauge"
         },
         "jvm/gc/count": {
             "description": "Garbage collection count", 
             "prometheus_metric_name": "druid_jvm_gc_count", 
+            "labels": "[]", 
             "type": "gauge"
         },
         "jvm/gc/cpu": {
@@ -95,26 +107,31 @@
             ], 
             "description": "Count of CPU time in Nanoseconds spent on garbage collection Note: jvm/gc/cpu represents the total time over multiple GC cycles; divide by jvm/gc/count to get the mean GC time per cycle", 
             "prometheus_metric_name": "druid_jvm_gc_cpu", 
+            "labels": "[]", 
             "type": "histogram"
         },
         "jvm/gc/mem/max": {
             "description": "druid_jvm_gc_mem_max", 
             "prometheus_metric_name": "druid_jvm_gc_mem_max", 
+            "labels": "[]", 
             "type": "gauge"
         },
         "jvm/gc/mem/capacity": {
             "description": "druid_jvm_gc_mem_capacity", 
             "prometheus_metric_name": "druid_jvm_gc_mem_capacity", 
+            "labels": "[]", 
             "type": "gauge"
         },
         "jvm/gc/mem/used": {
             "description": "druid_jvm_gc_mem_used", 
             "prometheus_metric_name": "druid_jvm_gc_mem_used", 
+            "labels": "[]", 
             "type": "gauge"
         },
         "jvm/gc/mem/init": {
             "description": "druid_jvm_gc_mem_init", 
             "prometheus_metric_name": "druid_jvm_gc_mem_init", 
+            "labels": "[]", 
             "type": "gauge"
         }
     },

--- a/conf/druid_0_18_0.json
+++ b/conf/druid_0_18_0.json
@@ -2,368 +2,392 @@
     "router": {
         "jvm/heapAlloc/bytes": {
             "buckets": [
-                "10", 
-                "100", 
-                "500", 
-                "1000", 
-                "2000", 
-                "3000", 
-                "5000", 
-                "7000", 
-                "10000", 
-                "inf", 
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
                 "sum"
-            ], 
-            "description": "druid_jvm_heapAlloc_bytes", 
-            "labels": "[]", 
-            "prometheus_metric_name": "druid_jvm_heapAlloc_bytes", 
+            ],
+            "description": "druid_jvm_heapAlloc_bytes",
+            "labels": [],
+            "prometheus_metric_name": "druid_jvm_heapAlloc_bytes",
             "type": "histogram"
-        },    
+        },
         "jetty/numOpenConnections": {
-            "description": "Number of open jetty connections.", 
-            "labels": "[]", 
-            "prometheus_metric_name": "druid_jetty_numOpenConnections", 
+            "description": "Number of open jetty connections.",
+            "labels": [],
+            "prometheus_metric_name": "druid_jetty_numOpenConnections",
             "type": "gauge"
         },
         "query/time": {
             "buckets": [
-                "10", 
-                "100", 
-                "500", 
-                "1000", 
-                "2000", 
-                "3000", 
-                "5000", 
-                "7000", 
-                "10000", 
-                "inf", 
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
                 "sum"
-            ], 
-            "description": "Milliseconds taken to complete a query", 
-            "labels": "dataSource", 
-            "prometheus_metric_name": "druid_query_time", 
+            ],
+            "description": "Milliseconds taken to complete a query",
+            "labels": [
+                "dataSource"
+            ],
+            "prometheus_metric_name": "druid_query_time",
             "type": "histogram"
         },
         "jvm/mem/committed": {
-            "description": "Committed memory", 
-            "prometheus_metric_name": "druid_jvm_mem_committed", 
-            "labels": "[]", 
+            "description": "Committed memory",
+            "prometheus_metric_name": "druid_jvm_mem_committed",
+            "labels": [],
             "type": "gauge"
         },
         "jvm/mem/used": {
-            "description": "Used memory", 
-            "prometheus_metric_name": "druid_jvm_mem_used", 
-            "labels": "[]", 
+            "description": "Used memory",
+            "prometheus_metric_name": "druid_jvm_mem_used",
+            "labels": [],
             "type": "gauge"
         },
         "jvm/mem/init": {
-            "description": "Initial memory", 
-            "prometheus_metric_name": "druid_jvm_mem_init", 
-            "labels": "[]", 
+            "description": "Initial memory",
+            "prometheus_metric_name": "druid_jvm_mem_init",
+            "labels": [],
             "type": "gauge"
         },
         "jvm/mem/max": {
-            "description": "Max memory", 
-            "prometheus_metric_name": "druid_jvm_mem_max", 
-            "labels": "[]", 
+            "description": "Max memory",
+            "prometheus_metric_name": "druid_jvm_mem_max",
+            "labels": [],
             "type": "gauge"
         },
         "jvm/pool/max": {
-            "description": "Max pool", 
-            "prometheus_metric_name": "druid_jvm_pool_max", 
-            "labels": "[]", 
+            "description": "Max pool",
+            "prometheus_metric_name": "druid_jvm_pool_max",
+            "labels": [],
             "type": "gauge"
         },
         "jvm/pool/committed": {
-            "description": "Committed pool", 
-            "prometheus_metric_name": "druid_jvm_pool_committed", 
-            "labels": "[]", 
+            "description": "Committed pool",
+            "prometheus_metric_name": "druid_jvm_pool_committed",
+            "labels": [],
             "type": "gauge"
         },
         "jvm/pool/used": {
-            "description": "Pool used", 
-            "prometheus_metric_name": "druid_jvm_pool_used", 
-            "labels": "[]", 
+            "description": "Pool used",
+            "prometheus_metric_name": "druid_jvm_pool_used",
+            "labels": [],
             "type": "gauge"
         },
         "jvm/pool/init": {
-            "description": "Initial pool", 
-            "prometheus_metric_name": "druid_jvm_pool_init", 
-            "labels": "[]", 
+            "description": "Initial pool",
+            "prometheus_metric_name": "druid_jvm_pool_init",
+            "labels": [],
             "type": "gauge"
         },
         "jvm/bufferpool/capacity": {
-            "description": "Bufferpool capacity", 
-            "prometheus_metric_name": "druid_jvm_bufferpool_capacity", 
-            "labels": "[]", 
+            "description": "Bufferpool capacity",
+            "prometheus_metric_name": "druid_jvm_bufferpool_capacity",
+            "labels": [],
             "type": "gauge"
         },
         "jvm/bufferpool/used": {
-            "description": "Bufferpool used", 
-            "prometheus_metric_name": "druid_jvm_bufferpool_used", 
-            "labels": "[]", 
+            "description": "Bufferpool used",
+            "prometheus_metric_name": "druid_jvm_bufferpool_used",
+            "labels": [],
             "type": "gauge"
         },
         "jvm/bufferpool/count": {
-            "description": "Bufferpool count", 
-            "prometheus_metric_name": "druid_jvm_bufferpool_count", 
-            "labels": "[]", 
+            "description": "Bufferpool count",
+            "prometheus_metric_name": "druid_jvm_bufferpool_count",
+            "labels": [],
             "type": "gauge"
         },
         "jvm/gc/count": {
-            "description": "Garbage collection count", 
-            "prometheus_metric_name": "druid_jvm_gc_count", 
-            "labels": "[]", 
+            "description": "Garbage collection count",
+            "prometheus_metric_name": "druid_jvm_gc_count",
+            "labels": [],
             "type": "gauge"
         },
         "jvm/gc/cpu": {
             "buckets": [
-                "10", 
-                "100", 
-                "500", 
-                "1000", 
-                "2000", 
-                "3000", 
-                "5000", 
-                "7000", 
-                "10000", 
-                "inf", 
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
                 "sum"
-            ], 
-            "description": "Count of CPU time in Nanoseconds spent on garbage collection Note: jvm/gc/cpu represents the total time over multiple GC cycles; divide by jvm/gc/count to get the mean GC time per cycle", 
-            "prometheus_metric_name": "druid_jvm_gc_cpu", 
-            "labels": "[]", 
+            ],
+            "description": "Count of CPU time in Nanoseconds spent on garbage collection Note: jvm/gc/cpu represents the total time over multiple GC cycles; divide by jvm/gc/count to get the mean GC time per cycle",
+            "prometheus_metric_name": "druid_jvm_gc_cpu",
+            "labels": [],
             "type": "histogram"
         },
         "jvm/gc/mem/max": {
-            "description": "druid_jvm_gc_mem_max", 
-            "prometheus_metric_name": "druid_jvm_gc_mem_max", 
-            "labels": "[]", 
+            "description": "druid_jvm_gc_mem_max",
+            "prometheus_metric_name": "druid_jvm_gc_mem_max",
+            "labels": [],
             "type": "gauge"
         },
         "jvm/gc/mem/capacity": {
-            "description": "druid_jvm_gc_mem_capacity", 
-            "prometheus_metric_name": "druid_jvm_gc_mem_capacity", 
-            "labels": "[]", 
+            "description": "druid_jvm_gc_mem_capacity",
+            "prometheus_metric_name": "druid_jvm_gc_mem_capacity",
+            "labels": [],
             "type": "gauge"
         },
         "jvm/gc/mem/used": {
-            "description": "druid_jvm_gc_mem_used", 
-            "prometheus_metric_name": "druid_jvm_gc_mem_used", 
-            "labels": "[]", 
+            "description": "druid_jvm_gc_mem_used",
+            "prometheus_metric_name": "druid_jvm_gc_mem_used",
+            "labels": [],
             "type": "gauge"
         },
         "jvm/gc/mem/init": {
-            "description": "druid_jvm_gc_mem_init", 
-            "prometheus_metric_name": "druid_jvm_gc_mem_init", 
-            "labels": "[]", 
+            "description": "druid_jvm_gc_mem_init",
+            "prometheus_metric_name": "druid_jvm_gc_mem_init",
+            "labels": [],
             "type": "gauge"
         }
     },
     "broker": {
         "namespace/cache/heapSizeInBytes": {
-            "description": "druid_namespace_cache_heapSizeInBytes", 
-            "labels": "[]", 
-            "prometheus_metric_name": "druid_namespace_cache_heapSizeInBytes", 
+            "description": "druid_namespace_cache_heapSizeInBytes",
+            "labels": [],
+            "prometheus_metric_name": "druid_namespace_cache_heapSizeInBytes",
             "type": "gauge"
         },
         "jvm/gc/mem/init": {
-            "description": "druid_jvm_gc_mem_init", 
-            "labels": "[]", 
-            "prometheus_metric_name": "druid_jvm_gc_mem_init", 
+            "description": "druid_jvm_gc_mem_init",
+            "labels": [],
+            "prometheus_metric_name": "druid_jvm_gc_mem_init",
             "type": "gauge"
         },
         "jvm/gc/mem/capacity": {
-            "description": "druid_jvm_gc_mem_capacity", 
-            "labels": "[]", 
-            "prometheus_metric_name": "druid_jvm_gc_mem_capacity", 
+            "description": "druid_jvm_gc_mem_capacity",
+            "labels": [],
+            "prometheus_metric_name": "druid_jvm_gc_mem_capacity",
             "type": "gauge"
         },
         "jvm/gc/mem/max": {
-            "description": "druid_jvm_gc_mem_max", 
-            "labels": "[]", 
-            "prometheus_metric_name": "druid_jvm_gc_mem_max", 
+            "description": "druid_jvm_gc_mem_max",
+            "labels": [],
+            "prometheus_metric_name": "druid_jvm_gc_mem_max",
             "type": "gauge"
-        },    
+        },
         "jvm/gc/cpu": {
             "buckets": [
-                "10", 
-                "100", 
-                "500", 
-                "1000", 
-                "2000", 
-                "3000", 
-                "5000", 
-                "7000", 
-                "10000", 
-                "inf", 
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
                 "sum"
-            ], 
-            "description": "Count of CPU time in Nanoseconds spent on garbage collection. Note: jvm/gc/cpu represents the total time over multiple GC cycles; divide by jvm/gc/count to get the mean GC time per cycle", 
-            "labels": "[]", 
-            "prometheus_metric_name": "druid_jvm_gc_cpu", 
+            ],
+            "description": "Count of CPU time in Nanoseconds spent on garbage collection. Note: jvm/gc/cpu represents the total time over multiple GC cycles; divide by jvm/gc/count to get the mean GC time per cycle",
+            "labels": [],
+            "prometheus_metric_name": "druid_jvm_gc_cpu",
             "type": "histogram"
-        },    
+        },
         "jvm/gc/count": {
-            "description": "Garbage collection count.", 
-            "labels": "[]", 
-            "prometheus_metric_name": "druid_jvm_gc_count", 
+            "description": "Garbage collection count.",
+            "labels": [],
+            "prometheus_metric_name": "druid_jvm_gc_count",
             "type": "gauge"
         },
         "jvm/bufferpool/count": {
-            "description": "Bufferpool count.", 
-            "labels": "bufferpoolName", 
-            "prometheus_metric_name": "druid_jvm_bufferpool_count", 
+            "description": "Bufferpool count.",
+            "labels": [
+                "bufferpoolName"
+            ],
+            "prometheus_metric_name": "druid_jvm_bufferpool_count",
             "type": "gauge"
         },
         "jvm/bufferpool/used": {
-            "description": "Bufferpool used.", 
-            "labels": "bufferpoolName", 
-            "prometheus_metric_name": "druid_jvm_bufferpool_used", 
+            "description": "Bufferpool used.",
+            "labels": [
+                "bufferpoolName"
+            ],
+            "prometheus_metric_name": "druid_jvm_bufferpool_used",
             "type": "gauge"
         },
         "jvm/bufferpool/capacity": {
-            "description": "Bufferpool capacity.", 
-            "labels": "bufferpoolName", 
-            "prometheus_metric_name": "druid_jvm_bufferpool_capacity", 
+            "description": "Bufferpool capacity.",
+            "labels": [
+                "bufferpoolName"
+            ],
+            "prometheus_metric_name": "druid_jvm_bufferpool_capacity",
             "type": "gauge"
         },
         "jvm/pool/init": {
-            "description": "Initial pool.", 
-            "labels": "[]", 
-            "prometheus_metric_name": "druid_jvm_pool_init", 
+            "description": "Initial pool.",
+            "labels": [],
+            "prometheus_metric_name": "druid_jvm_pool_init",
             "type": "gauge"
-        },    
+        },
         "jvm/pool/used": {
-            "description": "Pool used.", 
-            "labels": "[]", 
-            "prometheus_metric_name": "druid_jvm_pool_used", 
+            "description": "Pool used.",
+            "labels": [],
+            "prometheus_metric_name": "druid_jvm_pool_used",
             "type": "gauge"
-        },    
+        },
         "jvm/pool/committed": {
-            "description": "Committed pool.", 
-            "labels": "[]", 
-            "prometheus_metric_name": "druid_jvm_pool_committed", 
+            "description": "Committed pool.",
+            "labels": [],
+            "prometheus_metric_name": "druid_jvm_pool_committed",
             "type": "gauge"
-        },    
+        },
         "jvm/pool/max": {
-            "description": "Max pool.", 
-            "labels": "[]", 
-            "prometheus_metric_name": "druid_jvm_pool_max", 
+            "description": "Max pool.",
+            "labels": [],
+            "prometheus_metric_name": "druid_jvm_pool_max",
             "type": "gauge"
-        },    
+        },
         "jvm/mem/init": {
-            "description": "Initial memory.", 
-            "labels": "memKind", 
-            "prometheus_metric_name": "druid_jvm_mem_init", 
+            "description": "Initial memory.",
+            "labels": [
+                "memKind"
+            ],
+            "prometheus_metric_name": "druid_jvm_mem_init",
             "type": "gauge"
-        },    
+        },
         "jvm/mem/used": {
-            "description": "Used memory.", 
-            "labels": "memKind", 
-            "prometheus_metric_name": "druid_jvm_mem_used", 
+            "description": "Used memory.",
+            "labels": [
+                "memKind"
+            ],
+            "prometheus_metric_name": "druid_jvm_mem_used",
             "type": "gauge"
-        },    
+        },
         "jvm/mem/committed": {
-            "description": "Committed memory.", 
-            "labels": "memKind", 
-            "prometheus_metric_name": "druid_jvm_mem_committed", 
+            "description": "Committed memory.",
+            "labels": [
+                "memKind"
+            ],
+            "prometheus_metric_name": "druid_jvm_mem_committed",
             "type": "gauge"
-        },    
+        },
         "jvm/mem/max": {
-            "description": "Max memory.", 
-            "labels": "memKind", 
-            "prometheus_metric_name": "druid_jvm_mem_max", 
+            "description": "Max memory.",
+            "labels": [
+                "memKind"
+            ],
+            "prometheus_metric_name": "druid_jvm_mem_max",
             "type": "gauge"
-        },    
+        },
         "jetty/numOpenConnections": {
-            "description": "Number of open jetty connections.", 
-            "labels": "[]", 
-            "prometheus_metric_name": "druid_jetty_numOpenConnections", 
+            "description": "Number of open jetty connections.",
+            "labels": [],
+            "prometheus_metric_name": "druid_jetty_numOpenConnections",
             "type": "gauge"
         },
         "query/cpu/time": {
             "buckets": [
-                "10", 
-                "100", 
-                "500", 
-                "1000", 
-                "2000", 
-                "3000", 
-                "5000", 
-                "7000", 
-                "10000", 
-                "inf", 
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
                 "sum"
-            ], 
-            "description": "Microseconds of CPU time taken to complete a query", 
-            "labels": "dataSource", 
-            "prometheus_metric_name": "druid_query_cpu_time", 
+            ],
+            "description": "Microseconds of CPU time taken to complete a query",
+            "labels": [
+                "dataSource"
+            ],
+            "prometheus_metric_name": "druid_query_cpu_time",
             "type": "histogram"
         },
         "query/node/ttfb": {
-            "description": "Time to first byte. Milliseconds elapsed until Broker starts receiving the response from individual historical/realtime processes.", 
-            "labels": "dataSource", 
-            "prometheus_metric_name": "druid_query_node_ttfb", 
+            "description": "Time to first byte. Milliseconds elapsed until Broker starts receiving the response from individual historical/realtime processes.",
+            "labels": [
+                "dataSource"
+            ],
+            "prometheus_metric_name": "druid_query_node_ttfb",
             "type": "gauge"
-        },    
+        },
         "query/node/bytes": {
             "buckets": [
-                "10", 
-                "100", 
-                "500", 
-                "1000", 
-                "2000", 
-                "3000", 
-                "5000", 
-                "7000", 
-                "10000", 
-                "inf", 
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
                 "sum"
-            ], 
-            "description": "number of bytes returned from querying individual historical/realtime processes.", 
-            "labels": "dataSource", 
-            "prometheus_metric_name": "druid_query_node_bytes", 
+            ],
+            "description": "number of bytes returned from querying individual historical/realtime processes.",
+            "labels": [
+                "dataSource"
+            ],
+            "prometheus_metric_name": "druid_query_node_bytes",
             "type": "histogram"
-        },      
+        },
         "query/node/time": {
             "buckets": [
-                "10", 
-                "100", 
-                "500", 
-                "1000", 
-                "2000", 
-                "3000", 
-                "5000", 
-                "7000", 
-                "10000", 
-                "inf", 
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
                 "sum"
-            ], 
-            "description": "Milliseconds taken to query individual historical/realtime processes.", 
-            "labels": "dataSource", 
-            "prometheus_metric_name": "druid_query_node_time", 
+            ],
+            "description": "Milliseconds taken to query individual historical/realtime processes.",
+            "labels": [
+                "dataSource"
+            ],
+            "prometheus_metric_name": "druid_query_node_time",
             "type": "histogram"
-        },    
+        },
         "jvm/heapAlloc/bytes": {
             "buckets": [
-                "10", 
-                "100", 
-                "500", 
-                "1000", 
-                "2000", 
-                "3000", 
-                "5000", 
-                "7000", 
-                "10000", 
-                "inf", 
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
                 "sum"
-            ], 
-            "description": "druid_jvm_heapAlloc_bytes", 
-            "labels": "[]", 
-            "prometheus_metric_name": "druid_jvm_heapAlloc_bytes", 
+            ],
+            "description": "druid_jvm_heapAlloc_bytes",
+            "labels": [],
+            "prometheus_metric_name": "druid_jvm_heapAlloc_bytes",
             "type": "histogram"
-        },    
+        },
         "query/time": {
             "prometheus_metric_name": "druid_broker_query_time_ms",
             "type": "histogram",
@@ -409,52 +433,56 @@
         },
         "sqlQuery/time": {
             "buckets": [
-                "10", 
-                "100", 
-                "500", 
-                "1000", 
-                "2000", 
-                "3000", 
-                "5000", 
-                "7000", 
-                "10000", 
-                "inf", 
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
                 "sum"
-            ], 
-            "description": "Milliseconds taken to complete a SQL.", 
-            "labels": "dataSource", 
-            "prometheus_metric_name": "druid_sqlQuery_time", 
+            ],
+            "description": "Milliseconds taken to complete a SQL.",
+            "labels": [
+                "dataSource"
+            ],
+            "prometheus_metric_name": "druid_sqlQuery_time",
             "type": "histogram"
         },
         "sqlQuery/bytes": {
             "buckets": [
-                "10", 
-                "100", 
-                "500", 
-                "1000", 
-                "2000", 
-                "3000", 
-                "5000", 
-                "7000", 
-                "10000", 
-                "inf", 
+                "10",
+                "100",
+                "500",
+                "1000",
+                "2000",
+                "3000",
+                "5000",
+                "7000",
+                "10000",
+                "inf",
                 "sum"
-            ], 
-            "description": "number of bytes returned in SQL response.", 
-            "labels": "dataSource", 
-            "prometheus_metric_name": "druid_sqlQuery_bytes", 
+            ],
+            "description": "number of bytes returned in SQL response.",
+            "labels": [
+                "dataSource"
+            ],
+            "prometheus_metric_name": "druid_sqlQuery_bytes",
             "type": "histogram"
         },
         "namespace/cache/numEntries": {
-            "description": "druid_namespace_cache_numEntries", 
-            "labels": "[]", 
-            "prometheus_metric_name": "druid_namespace_cache_numEntries", 
+            "description": "druid_namespace_cache_numEntries",
+            "labels": [],
+            "prometheus_metric_name": "druid_namespace_cache_numEntries",
             "type": "gauge"
         },
         "namespace/deltaTasksStarted": {
-            "description": "druid_namespace_deltaTasksStarted", 
-            "labels": "[]", 
-            "prometheus_metric_name": "druid_namespace_deltaTasksStarted", 
+            "description": "druid_namespace_deltaTasksStarted",
+            "labels": [],
+            "prometheus_metric_name": "druid_namespace_deltaTasksStarted",
             "type": "gauge"
         },
         "query/cache/total/numEntries": {

--- a/druid_exporter/exporter.py
+++ b/druid_exporter/exporter.py
@@ -65,7 +65,7 @@ def check_metrics_config_file_consistency(json_config):
         raise RuntimeError('Validation error: empty config file.')
     # The first level of nesting should be related to Druid daemon names
     druid_daemon_names = [
-        'middlemanager', 'historical', 'peon', 'broker', 'coordinator', 'overlord']
+        'middlemanager', 'historical', 'peon', 'broker', 'coordinator', 'overlord', 'router']
     required_config_fields = [
         'prometheus_metric_name', 'labels', 'type', 'description'
     ]

--- a/utils/Readme.md
+++ b/utils/Readme.md
@@ -1,0 +1,80 @@
+# Utilities to help with the generation of new config files
+
+## Description
+
+Since the amount of metrics that druid can generate is big and can change from version to version we developed this small utility to convert the error messages from the exporter into configuration blocks that can be used with the new json configuration.
+
+The idea is to run the exporter in debug mode `-d` and send the output to the `parse_failed_logs.py` script.
+
+The script will look for lines with the format:
+
+
+    DEBUG:druid_exporter.collector:The following datapoint is not supported, either because the 'feed' field is not 'metrics' or the metric itself is not supported: {'feed': 'metrics', 'timestamp': '2020-05-07T09:57:08.983Z', 'service': 'druid/router', 'host': '10.132.0.27:8888', 'version': '0.18.0', 'metric': 'query/time', 'value': 7, 'context': {'queryId': '2c08a196-9c11-49c3-a5e7-b41357388f24', 'timeout': 40000}, 'dataSource': 'datasource_test_1', 'duration': 'PT9223372036854775.807S', 'hasFilters': 'false', 'id': '2c08a196-9c11-49c3-a5e7-b41357388f24', 'interval': ['-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z'], 'remoteAddress': '10.0.3.217', 'success': 'true', 'type': 'timeBoundary'}
+
+and it will output something like this:
+
+    ----------------
+    Found metric: 
+    {
+        "context": {
+            "queryId": "2c08a196-9c11-49c3-a5e7-b41357388f24", 
+            "timeout": 40000
+        }, 
+        "dataSource": "datasource_test_1", 
+        "duration": "PT9223372036854775.807S", 
+        "feed": "metrics", 
+        "hasFilters": "false", 
+        "host": "10.132.0.27:8888", 
+        "id": "2c08a196-9c11-49c3-a5e7-b41357388f24", 
+        "interval": [
+            "-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z"
+        ], 
+        "metric": "query/time", 
+        "remoteAddress": "10.0.3.217", 
+        "service": "druid/router", 
+        "success": "true", 
+        "timestamp": "2020-05-07T09:57:08.983Z", 
+        "type": "timeBoundary", 
+        "value": 7, 
+        "version": "0.18.0"
+    }
+
+    This is a metric for: druid/router
+    Adding dataSource as label for prometheus.
+    {
+        "query/time": {
+            "buckets": [
+                "10", 
+                "100", 
+                "500", 
+                "1000", 
+                "2000", 
+                "3000", 
+                "5000", 
+                "7000", 
+                "10000", 
+                "inf", 
+                "sum"
+            ], 
+            "description": "Milliseconds taken to complete a query.", 
+            "labels": [
+                "dataSource"
+            ], 
+            "prometheus_metric_name": "druid_query_time", 
+            "type": "histogram"
+        }
+    }
+
+## Notes
+
+The file with the descriptions is generated from the druid official page. <https://druid.apache.org/docs/latest/operations/metrics.html>
+
+If you want to send the output via pipe you need to redirect the output like this:
+
+    druid_exporter -d ../conf/druid_0_18_0.json 2>&1 | ./parse_failed_logs.py
+
+Every missing metric is parsed only once per execution. So you won't see the same block several times.
+
+I can't guarantee that the heuristic to guess if the metric should be gauge or histogram or the labels is perfect.
+
+Keep in mind that this is just an utility to help you to find and generate new configuration blocks for missing metrics, but you should review them before adding them to the final config file.

--- a/utils/descriptions.txt
+++ b/utils/descriptions.txt
@@ -1,0 +1,78 @@
+query/time	Milliseconds taken to complete a query.
+query/bytes	number of bytes returned in query response.
+query/node/time	Milliseconds taken to query individual historical/realtime processes.
+query/node/bytes	number of bytes returned from querying individual historical/realtime processes.
+query/node/ttfb	Time to first byte. Milliseconds elapsed until Broker starts receiving the response from individual historical/realtime processes.
+query/node/backpressure	Milliseconds that the channel to this process has spent suspended due to backpressure.
+query/count	number of total queries
+query/success/count	number of queries successfully processed
+query/failed/count	number of failed queries
+query/interrupted/count	number of queries interrupted due to cancellation or timeout
+sqlQuery/time	Milliseconds taken to complete a SQL query.
+sqlQuery/bytes	number of bytes returned in SQL query response.
+	
+query/time	Milliseconds taken to complete a query.
+query/segment/time	Milliseconds taken to query individual segment. Includes time to page in the segment from disk.
+query/wait/time	Milliseconds spent waiting for a segment to be scanned.
+segment/scan/pending	Number of segments in queue waiting to be scanned.
+query/segmentAndCache/time	Milliseconds taken to query individual segment or hit the cache (if it is enabled on the Historical process).
+query/cpu/time	Microseconds of CPU time taken to complete a query
+query/count	number of total queries
+query/success/count	number of queries successfully processed
+query/failed/count	number of failed queries
+query/interrupted/count	number of queries interrupted due to cancellation or timeout
+	
+query/time	Milliseconds taken to complete a query.
+query/wait/time	Milliseconds spent waiting for a segment to be scanned.
+segment/scan/pending	Number of segments in queue waiting to be scanned.
+query/count	number of total queries
+query/success/count	number of queries successfully processed
+query/failed/count	number of failed queries
+query/interrupted/count	number of queries interrupted due to cancellation or timeout
+	
+jetty/numOpenConnections	Number of open jetty connections.
+	
+sqlQuery/time	Milliseconds taken to complete a SQL.
+sqlQuery/bytes	number of bytes returned in SQL response.
+	
+segment/assigned/count	Number of segments assigned to be loaded in the cluster.
+segment/moved/count	Number of segments moved in the cluster.
+segment/dropped/count	Number of segments dropped due to being overshadowed.
+segment/deleted/count	Number of segments dropped due to rules.
+segment/unneeded/count	Number of segments dropped due to being marked as unused.
+segment/cost/raw	Used in cost balancing. The raw cost of hosting segments.
+segment/cost/normalization	Used in cost balancing. The normalization of hosting segments.
+segment/cost/normalized	Used in cost balancing. The normalized cost of hosting segments.
+segment/loadQueue/size	Size in bytes of segments to load.
+segment/loadQueue/failed	Number of segments that failed to load.
+segment/loadQueue/count	Number of segments to load.
+segment/dropQueue/count	Number of segments to drop.
+segment/size	Total size of used segments in a data source. Emitted only for data sources to which at least one used segment belongs.
+segment/count	Number of used segments belonging to a data source. Emitted only for data sources to which at least one used segment belongs.
+segment/overShadowed/count	Number of overshadowed segments.
+segment/unavailable/count	Number of segments (not including replicas) left to load until segments that should be loaded in the cluster are available for queries.
+segment/underReplicated/count	Number of segments (including replicas) left to load until segments that should be loaded in the cluster are available for queries.
+tier/historical/count	Number of available historical nodes in each tier.
+tier/replication/factor	Configured maximum replication factor in each tier.
+tier/required/capacity	Total capacity in bytes required in each tier.
+tier/total/capacity	Total capacity in bytes available in each tier.
+	
+segment/max	Maximum byte limit available for segments.
+segment/used	Bytes used for served segments.
+segment/usedPercent	Percentage of space used by served segments.
+segment/count	Number of served segments.
+segment/pendingDelete	On-disk size in bytes of segments that are waiting to be cleared out
+	
+jvm/pool/committed	Committed pool.
+jvm/pool/init	Initial pool.
+jvm/pool/max	Max pool.
+jvm/pool/used	Pool used.
+jvm/bufferpool/count	Bufferpool count.
+jvm/bufferpool/used	Bufferpool used.
+jvm/bufferpool/capacity	Bufferpool capacity.
+jvm/mem/init	Initial memory.
+jvm/mem/max	Max memory.
+jvm/mem/used	Used memory.
+jvm/mem/committed	Committed memory.
+jvm/gc/count	Garbage collection count.
+jvm/gc/cpu	Count of CPU time in Nanoseconds spent on garbage collection. Note: jvm/gc/cpu represents the total time over multiple GC cycles; divide by jvm/gc/count to get the mean GC time per cycle

--- a/utils/parse_failed_log.py
+++ b/utils/parse_failed_log.py
@@ -127,10 +127,10 @@ for line in sys.stdin:
     if 'dataSource' in parsed_json.keys():
         print("Found dataSource. Adding it as label for prometheus.")
         output_json[metric_name]['labels'] = "dataSource"
-    if 'memKind' in parsed_json.keys():
+    elif 'memKind' in parsed_json.keys():
         print("Found memKind. Adding it as label for prometheus.")
         output_json[metric_name]['labels'] = "memKind"
-    if 'bufferpoolName' in parsed_json.keys():
+    elif 'bufferpoolName' in parsed_json.keys():
         print("Found bufferpoolName. Adding it as label for prometheus.")
         output_json[metric_name]['labels'] = "bufferpoolName"
     else:

--- a/utils/parse_failed_log.py
+++ b/utils/parse_failed_log.py
@@ -124,17 +124,18 @@ for line in sys.stdin:
     else:
         output_json[metric_name]["description"] = "druid_{0}".format(metric_name.replace('/','_'))
     
-    if 'dataSource' in parsed_json.keys():
-        print("Found dataSource. Adding it as label for prometheus.")
-        output_json[metric_name]['labels'] = "dataSource"
-    elif 'memKind' in parsed_json.keys():
-        print("Found memKind. Adding it as label for prometheus.")
-        output_json[metric_name]['labels'] = "memKind"
-    elif 'bufferpoolName' in parsed_json.keys():
-        print("Found bufferpoolName. Adding it as label for prometheus.")
-        output_json[metric_name]['labels'] = "bufferpoolName"
-    else:
-         output_json[metric_name]['labels'] = '[]'
+    
+    # Some heuristic to guess the labels
+    possible_labels = ["dataSource", "memKind", "bufferpoolName"]
+    labels = "[]" # By default it needs the field label even with an empty list.
+
+    for possible_label in possible_labels:
+        if possible_label in parsed_json.keys():
+            print("Adding {0} it as label for prometheus.".format(possible_label))
+            labels = possible_label
+    
+    output_json[metric_name]['labels'] = labels
+
     
     # Some light heuristic to guess the type.
     if re.search("/time$|/bytes$|/cpu$", parsed_json['metric']):

--- a/utils/parse_failed_log.py
+++ b/utils/parse_failed_log.py
@@ -124,17 +124,15 @@ for line in sys.stdin:
     else:
         output_json[metric_name]["description"] = "druid_{0}".format(metric_name.replace('/','_'))
     
-    
+
     # Some heuristic to guess the labels
     possible_labels = ["dataSource", "memKind", "bufferpoolName"]
-    labels = "[]" # By default it needs the field label even with an empty list.
+    output_json[metric_name]['labels'] = [] # By default it needs the field label even with an empty list.
 
     for possible_label in possible_labels:
         if possible_label in parsed_json.keys():
             print("Adding {0} it as label for prometheus.".format(possible_label))
-            labels = possible_label
-    
-    output_json[metric_name]['labels'] = labels
+            output_json[metric_name]['labels'].append(possible_label)
 
     
     # Some light heuristic to guess the type.

--- a/utils/parse_failed_log.py
+++ b/utils/parse_failed_log.py
@@ -1,0 +1,157 @@
+#!/usr/bin/python
+# Copyright 2020 Luca Toscano
+#                Filippo Giunchedi
+#                Wikimedia Foundation
+#                Rafa Diaz
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# All the failed metris are written in the log with a similar format:
+#
+# DEBUG:druid_exporter.collector:The following datapoint is not supported, either because the 'feed' field is not 'metrics' or the metric itself is not supported: {'feed': 'metrics', 'timestamp': '2020-05-07T09:57:08.983Z', 'service': 'druid/router', 'host': '10.132.0.27:8888', 'version': '0.18.0', 'metric': 'query/time', 'value': 7, 'context': {'queryId': '2c08a196-9c11-49c3-a5e7-b41357388f24', 'timeout': 40000}, 'dataSource': 'daily_page_export', 'duration': 'PT9223372036854775.807S', 'hasFilters': 'false', 'id': '2c08a196-9c11-49c3-a5e7-b41357388f24', 'interval': ['-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z'], 'remoteAddress': '10.0.3.217', 'success': 'true', 'type': 'timeBoundary'}
+# 
+# [{"feed":"metrics","timestamp":"2020-04-23T11:36:27.866Z","service":"druid/peon","host":"druid1001.eqiad.wmnet:8201",
+# "version":"0.12.3","metric":"ingest/events/unparseable","value":0,"dataSource":"wmf_netflow",
+# "taskId":["index_kafka_wmf_netflow_ee74c5a5820837c_hedlopdm"]}]
+#
+# Which should be convert in something like this:
+# [..]
+#     "peon": {
+#     	[..]
+#         "ingest/events/unparseable": {
+#             "prometheus_metric_name": "druid_realtime_ingest_events_unparseable_count",
+#             "type": "gauge",
+#             "labels": ["dataSource"],
+#             "description": "Number of events rejected because the events are unparseable."
+#         },
+#         [..]
+# [..]
+#
+# [..]
+#     "json['service']": {
+#     	[..]
+#         "json['metrics']": {
+#             "prometheus_metric_name": "druid_+json['metric'].replace('/','_')",
+#             "type": "gauge",
+#             "labels": ["dataSource"], if json['dataSource"]
+#             "description": "put the metric separated with spaces here."
+#         },
+#         [..]
+# [..]
+#
+
+
+import argparse
+import json
+import logging
+import sys
+import re
+
+log = logging.getLogger(__name__)
+
+
+def load_descriptions():
+    desc_dict = {}
+
+    fd = open('descriptions.txt', 'r') 
+    lines = fd.readlines()
+    
+    # Strips the newline character 
+    for line in lines:
+        desc_match = re.match("(.*)\t(.*)",line) 
+        if (desc_match):
+            # print("Match")
+            desc_dict[desc_match.group(1)] = desc_match.group(2)
+        else:
+            print("No match")
+    return desc_dict
+
+def is_processed(service, metric):
+    if service not in processed_metrics:
+        processed_metrics[service] = []
+        processed_metrics[service].append(metric)
+        return False
+    if metric not in processed_metrics[service]:
+        processed_metrics[service].append(metric)
+        return False
+
+    return True
+
+
+p = re.compile("DEBUG:druid_exporter.collector:The following datapoint is not supported, either because the 'feed' field is not 'metrics' or the metric itself is not supported: (.*)")
+
+# Descriptions for metrics are taken from: https://druid.apache.org/docs/latest/operations/metrics.html
+descriptions = load_descriptions()
+# print(descriptions)
+
+processed_metrics = {}
+
+for line in sys.stdin:
+    unsupported_metric = p.search(line)
+
+    if unsupported_metric:
+        metric = unsupported_metric.group(1)
+        parsed_json = json.loads(metric.replace("'", '"'))
+        # print("found: {0}".format(unsupported_metric.group(1)))
+        
+        if is_processed(parsed_json['service'], parsed_json['metric']):
+            continue
+
+        print("\n\n----------------")
+        print("Found metric: ")
+        print(json.dumps(parsed_json, indent=4, sort_keys=True))
+    else:
+        continue
+
+    # print("matches: {1}".format(result.group(0)))
+    print("\nThis is a metric for: {0}".format(parsed_json['service']))
+    output_json = {}
+    metric_name = parsed_json['metric']
+    output_json[metric_name] = {}
+    output_json[metric_name]["prometheus_metric_name"] = "druid_{0}".format(metric_name.replace('/','_'))
+    # So far we don't have better way to guess a right description so this can be a temporary solution
+    if (metric_name in descriptions.keys()):
+        output_json[metric_name]["description"] = descriptions[metric_name]
+    else:
+        output_json[metric_name]["description"] = "druid_{0}".format(metric_name.replace('/','_'))
+    
+    
+    # Some heuristic to guess the labels
+    possible_labels = ["dataSource", "memKind", "bufferpoolName"]
+    labels = "[]" # By default it needs the field label even with an empty list.
+
+    for possible_label in possible_labels:
+        if possible_label in parsed_json.keys():
+            print("Adding {0} it as label for prometheus.".format(possible_label))
+            labels = possible_label
+    
+    output_json[metric_name]['labels'] = labels
+
+    
+    # Some light heuristic to guess the type.
+    if re.search("/time$|/bytes$|/cpu$", parsed_json['metric']):
+        output_json[metric_name]["type"] = "histogram"
+        output_json[metric_name]["buckets"] = [
+            "10", "100", "500", "1000", "2000", "3000", "5000", "7000", "10000", "inf", "sum"
+        ]
+    elif re.search("/count$|/failed$|/size$", parsed_json['metric']):
+        output_json[metric_name]["type"] = "gauge"
+    else :
+        print("Can't guess what type is this metrics: {0} Using Gauge as default type.".format(parsed_json['metric']))
+        output_json[metric_name]["type"] = "gauge"
+       
+
+    # new_metric = json.dumps(output_json)
+    print(json.dumps(output_json, indent=4, sort_keys=True))
+
+
+

--- a/utils/parse_failed_log.py
+++ b/utils/parse_failed_log.py
@@ -125,8 +125,14 @@ for line in sys.stdin:
         output_json[metric_name]["description"] = "druid_{0}".format(metric_name.replace('/','_'))
     
     if 'dataSource' in parsed_json.keys():
-        print("It maybe a dataSource Dimmension. Adding it as label for prometheus.")
+        print("Found dataSource. Adding it as label for prometheus.")
         output_json[metric_name]['labels'] = "dataSource"
+    if 'memKind' in parsed_json.keys():
+        print("Found memKind. Adding it as label for prometheus.")
+        output_json[metric_name]['labels'] = "memKind"
+    if 'bufferpoolName' in parsed_json.keys():
+        print("Found bufferpoolName. Adding it as label for prometheus.")
+        output_json[metric_name]['labels'] = "bufferpoolName"
     else:
          output_json[metric_name]['labels'] = '[]'
     

--- a/utils/parse_failed_log.py
+++ b/utils/parse_failed_log.py
@@ -1,0 +1,134 @@
+#!/usr/bin/python
+# Copyright 2020 Luca Toscano
+#                Filippo Giunchedi
+#                Wikimedia Foundation
+#                Rafa Diaz
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# All the failed metris are written in the log with a similar format:
+#
+# DEBUG:druid_exporter.collector:The following datapoint is not supported, either because the 'feed' field is not 'metrics' or the metric itself is not supported: {'feed': 'metrics', 'timestamp': '2020-05-07T09:57:08.983Z', 'service': 'druid/router', 'host': '10.132.0.27:8888', 'version': '0.18.0', 'metric': 'query/time', 'value': 7, 'context': {'queryId': '2c08a196-9c11-49c3-a5e7-b41357388f24', 'timeout': 40000}, 'dataSource': 'daily_page_export', 'duration': 'PT9223372036854775.807S', 'hasFilters': 'false', 'id': '2c08a196-9c11-49c3-a5e7-b41357388f24', 'interval': ['-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z'], 'remoteAddress': '10.0.3.217', 'success': 'true', 'type': 'timeBoundary'}
+# 
+# [{"feed":"metrics","timestamp":"2020-04-23T11:36:27.866Z","service":"druid/peon","host":"druid1001.eqiad.wmnet:8201",
+# "version":"0.12.3","metric":"ingest/events/unparseable","value":0,"dataSource":"wmf_netflow",
+# "taskId":["index_kafka_wmf_netflow_ee74c5a5820837c_hedlopdm"]}]
+#
+# Which should be convert in something like this:
+# [..]
+#     "peon": {
+#     	[..]
+#         "ingest/events/unparseable": {
+#             "prometheus_metric_name": "druid_realtime_ingest_events_unparseable_count",
+#             "type": "gauge",
+#             "labels": ["dataSource"],
+#             "description": "Number of events rejected because the events are unparseable."
+#         },
+#         [..]
+# [..]
+#
+# [..]
+#     "json['service']": {
+#     	[..]
+#         "json['metrics']": {
+#             "prometheus_metric_name": "druid_+json['metric'].replace('/','_')",
+#             "type": "gauge",
+#             "labels": ["dataSource"], if json['dataSource"]
+#             "description": "put the metric separated with spaces here."
+#         },
+#         [..]
+# [..]
+#
+
+
+import argparse
+import json
+import logging
+import sys
+import re
+
+log = logging.getLogger(__name__)
+
+
+def load_descriptions():
+    desc_dict = {}
+
+    fd = open('descriptions.txt', 'r') 
+    lines = fd.readlines()
+    
+    # Strips the newline character 
+    for line in lines:
+        desc_match = re.match("(.*)\t(.*)",line) 
+        if (desc_match):
+            # print("Match")
+            desc_dict[desc_match.group(1)] = desc_match.group(2)
+        else:
+            print("No match")
+    return desc_dict
+
+
+p = re.compile("DEBUG:druid_exporter.collector:The following datapoint is not supported, either because the 'feed' field is not 'metrics' or the metric itself is not supported: (.*)")
+
+# Descriptions for metrics are taken from: https://druid.apache.org/docs/latest/operations/metrics.html
+descriptions = load_descriptions()
+# print(descriptions)
+
+
+for line in sys.stdin:
+    unsupported_metric = p.search(line)
+
+    if unsupported_metric:
+        metric = unsupported_metric.group(1)
+        parsed_json = json.loads(metric.replace("'", '"'))
+        # print("found: {0}".format(unsupported_metric.group(1)))
+        print("\n\n----------------")
+        print("Found metric: ")
+        print(json.dumps(parsed_json, indent=4, sort_keys=True))
+    else:
+        continue
+
+    # print("matches: {1}".format(result.group(0)))
+    print("\nThis is a metric for: {0}".format(parsed_json['service']))
+    output_json = {}
+    metric_name = parsed_json['metric']
+    output_json[metric_name] = {}
+    output_json[metric_name]["prometheus_metric_name"] = "druid_{0}".format(metric_name.replace('/','_'))
+    # So far we don't have better way to guess a right description so this can be a temporary solution
+    if (metric_name in descriptions.keys()):
+        output_json[metric_name]["description"] = descriptions[metric_name]
+    else:
+        output_json[metric_name]["description"] = "druid_{0}".format(metric_name.replace('/','_'))
+    
+    if 'dataSource' in parsed_json.keys():
+        print("It maybe a dataSource Dimmension. Adding it as label for prometheus.")
+        output_json[metric_name]['labels'] = "dataSource"
+    else:
+         output_json[metric_name]['labels'] = '[]'
+    
+    # Some light heuristic to guess the type.
+    if re.search("/time$|/bytes$|/cpu$", parsed_json['metric']):
+        output_json[metric_name]["type"] = "histogram"
+        output_json[metric_name]["buckets"] = [
+            "10", "100", "500", "1000", "2000", "3000", "5000", "7000", "10000", "inf", "sum"
+        ]
+    elif re.search("/count$|/failed$|/size$", parsed_json['metric']):
+        output_json[metric_name]["type"] = "gauge"
+    else :
+        print("Can't guess what type is this metrics: {0} Using Gauge as default type.".format(parsed_json['metric']))
+        output_json[metric_name]["type"] = "gauge"
+       
+
+    # new_metric = json.dumps(output_json)
+    print(json.dumps(output_json, indent=4, sort_keys=True))
+
+
+

--- a/utils/parse_failed_log.py
+++ b/utils/parse_failed_log.py
@@ -1,8 +1,6 @@
 #!/usr/bin/python
-# Copyright 2020 Luca Toscano
-#                Filippo Giunchedi
-#                Wikimedia Foundation
-#                Rafa Diaz
+# Copyright 2020 Rafa Diaz
+# 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -35,19 +33,7 @@
 #         },
 #         [..]
 # [..]
-#
-# [..]
-#     "json['service']": {
-#     	[..]
-#         "json['metrics']": {
-#             "prometheus_metric_name": "druid_+json['metric'].replace('/','_')",
-#             "type": "gauge",
-#             "labels": ["dataSource"], if json['dataSource"]
-#             "description": "put the metric separated with spaces here."
-#         },
-#         [..]
-# [..]
-#
+
 
 
 import argparse

--- a/utils/parse_failed_log.py
+++ b/utils/parse_failed_log.py
@@ -57,8 +57,6 @@ def load_descriptions():
         if (desc_match):
             # print("Match")
             desc_dict[desc_match.group(1)] = desc_match.group(2)
-        else:
-            print("No match")
     return desc_dict
 
 def is_processed(service, metric):
@@ -117,7 +115,7 @@ for line in sys.stdin:
 
     for possible_label in possible_labels:
         if possible_label in parsed_json.keys():
-            print("Adding {0} it as label for prometheus.".format(possible_label))
+            print("Adding {0} as label for prometheus.".format(possible_label))
             output_json[metric_name]['labels'].append(possible_label)
 
     


### PR DESCRIPTION
* Add a configuration template for the V0.18 of druid.
* Add router as allowed deamon
* Add a utility to generate configuration block from the log of failed metrics.
So basically it converts this:

```
 DEBUG:druid_exporter.collector:The following datapoint is not supported, either because the 'feed' field is not 'metrics' or the metric itself is not supported: {'feed': 'metrics', 'timestamp': '2020-05-07T09:57:08.983Z', 'service': 'druid/router', 'host': '10.132.0.27:8888', 'version': '0.18.0', 'metric': 'query/time', 'value': 7, 'context': {'queryId': '2c08a196-9c11-49c3-a5e7-b41357388f24', 'timeout': 40000}, 'dataSource': 'datasource_test_1', 'duration': 'PT9223372036854775.807S', 'hasFilters': 'false', 'id': '2c08a196-9c11-49c3-a5e7-b41357388f24', 'interval': ['-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z'], 'remoteAddress': '10.0.3.217', 'success': 'true', 'type': 'timeBoundary'}
```

into this:

```
----------------
    Found metric: 
    {
        "context": {
            "queryId": "2c08a196-9c11-49c3-a5e7-b41357388f24", 
            "timeout": 40000
        }, 
        "dataSource": "datasource_test_1", 
        "duration": "PT9223372036854775.807S", 
        "feed": "metrics", 
        "hasFilters": "false", 
        "host": "10.132.0.27:8888", 
        "id": "2c08a196-9c11-49c3-a5e7-b41357388f24", 
        "interval": [
            "-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z"
        ], 
        "metric": "query/time", 
        "remoteAddress": "10.0.3.217", 
        "service": "druid/router", 
        "success": "true", 
        "timestamp": "2020-05-07T09:57:08.983Z", 
        "type": "timeBoundary", 
        "value": 7, 
        "version": "0.18.0"
    }

    This is a metric for: druid/router
    Adding dataSource as label for prometheus.
    {
        "query/time": {
            "buckets": [
                "10", 
                "100", 
                "500", 
                "1000", 
                "2000", 
                "3000", 
                "5000", 
                "7000", 
                "10000", 
                "inf", 
                "sum"
            ], 
            "description": "Milliseconds taken to complete a query.", 
            "labels": [
                "dataSource"
            ], 
            "prometheus_metric_name": "druid_query_time", 
            "type": "histogram"
        }
    }
```

So basically you just need to review if the config is OK and copy it in the right place inside the Json file.